### PR TITLE
Add env template and document secrets management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-DATABASE_URL=postgresql://postgres:postgres@db:5432/apgms?schema=public
-SHADOW_DATABASE_URL=postgresql://postgres:postgres@db:5432/apgms_shadow?schema=public
-
+NODE_ENV=development
 PORT=3000
-TAX_ENGINE_URL=http://tax-engine:8000
-WEBAPP_PORT=5173
-REDIS_URL=redis://redis:6379
+JWKS_URL=https://your-idp/.well-known/jwks.json
+JWT_ISSUER=https://your-idp/
+JWT_AUDIENCE=apgms
+CORS_ALLOWLIST=http://localhost:5173,https://app.apgms.dev
+LOG_LEVEL=info

--- a/docs/security/SECRETS.md
+++ b/docs/security/SECRETS.md
@@ -1,0 +1,30 @@
+# Secrets Management
+
+This document summarizes where security-sensitive configuration values are stored and who is
+responsible for rotating them.
+
+## Where secrets live
+
+- **Local development** – Developers should copy `.env.example` to `.env` and fill in the
+  environment-specific values. The `.env` file is git-ignored and should never be committed.
+- **Continuous integration** – Secrets required by pipelines are stored in the CI provider's
+  encrypted secret store (e.g., GitHub Actions repository or organization secrets). Access is
+  restricted to the security and platform teams.
+- **Shared staging/production environments** – Runtime secrets live in the managed secret
+  managers for each environment (e.g., AWS Secrets Manager or parameter store) and are injected at
+  deploy time via infrastructure automation.
+
+## Rotation cadence and owners
+
+- **Application authentication material (JWT keys, client secrets, signing certs)**
+  - *Owner*: Security engineering
+  - *Cadence*: Rotate at least every 90 days or immediately upon suspected compromise.
+- **Third-party integration credentials (APIs, webhooks)**
+  - *Owner*: Platform engineering
+  - *Cadence*: Rotate every 180 days or when vendors require regeneration.
+- **Infrastructure access tokens (CI deploy keys, cloud IAM users)**
+  - *Owner*: DevOps
+  - *Cadence*: Rotate quarterly and audit access monthly.
+
+All rotations must be recorded in the shared change log and communicated to affected teams at
+least one business day in advance whenever possible.


### PR DESCRIPTION
## Summary
- replace the sample `.env` file with the security-sensitive configuration template
- add security documentation describing where secrets are stored
- capture rotation cadences and responsible owners for critical secrets

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68f7a4bf7a7883279b3b0035eb93b211