### PR TITLE
feat: add audit logging for admin actions

### DIFF
--- a/docs/runbooks/security.md
+++ b/docs/runbooks/security.md
@@ -1,0 +1,20 @@
+# Security Runbook – Admin Audit Logs
+
+## Log storage
+- Audit events are written to the append-only sink described in [infra/audit/README.md](../../infra/audit/README.md).
+- Files are organized by the key prefix `audit/yyyy/mm/dd/*.jsonl`.
+
+## Access and retention
+- Enable immutable retention policies (WORM or retention lock) to prevent tampering.
+- Rotate credentials quarterly and enforce read-only IAM roles for security, compliance, and incident-response teams.
+- Retain audit data for a minimum of seven years unless local regulation requires a longer period.
+
+## Investigations
+- Search for entries with `type:"audit"` and filter by `corrId` to follow a single request through downstream systems.
+- Combine `action` and `orgId` filters to narrow investigations to a specific tenant or activity.
+- When redacted values (e.g., `***redacted***`) appear, coordinate with compliance to request an authorized reveal from the operational datastore if required.
+
+## On-call checklist
+1. Confirm append-only storage health (no failed lifecycle jobs, bucket retention intact).
+2. Verify that ingestion pipelines are current (no backlog > 5 minutes).
+3. Validate that redaction is functioning by sampling recent events for masked fields.

--- a/infra/audit/README.md
+++ b/infra/audit/README.md
@@ -1,0 +1,5 @@
+# Audit Log Sink
+
+Use an object storage bucket that supports write-once-read-many (WORM) retention locking or an append-only log stream service (for example, CloudWatch Logs with retention policies and restricted access).
+
+Store daily files with the prefix `audit/yyyy/mm/dd/…jsonl` to keep entries partitioned for efficient discovery.

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -13,7 +13,9 @@
     "@prisma/client": "6.17.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "pino": "^9.5.0",
+    "pino-pretty": "^11.2.2"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",

--- a/services/api-gateway/src/routes/admin.data.ts
+++ b/services/api-gateway/src/routes/admin.data.ts
@@ -1,6 +1,7 @@
 ﻿<<<<<<< HEAD
 import { createHash } from "node:crypto";
 import type { FastifyInstance, FastifyRequest } from "fastify";
+import { logger, withRedaction } from "@apgms/shared/logging";
 import {
   adminDataDeleteRequestSchema,
   adminDataDeleteResponseSchema,
@@ -205,6 +206,27 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
         occurredAt,
       });
     }
+
+    logger.info({
+      type: "audit",
+      action: "admin.data.delete",
+      orgId: body.orgId,
+      by: principal.id,
+      target: subject.id,
+      before: withRedaction({
+        user: {
+          id: subject.id,
+          email: subject.email,
+          orgId: subject.orgId,
+        },
+      }),
+      after: withRedaction({
+        action: response.action,
+        userId: subject.id,
+      }),
+      ts: new Date().toISOString(),
+      corrId: request.id,
+    });
 
     await securityLogger({
       event: "data_delete",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,24 +1,26 @@
 {
-    "name":  "@apgms/shared",
-    "version":  "0.1.0",
-    "private":  true,
-    "type":  "module",
-    "main":  "src/index.ts",
-    "types":  "src/index.ts",
-    "scripts":  {
-                    "prisma:generate":  "prisma generate --schema=shared/prisma/schema.prisma",
-                    "build":  "echo building shared"
-                },
-    "dependencies":  {
-                         "@prisma/client":  "6.17.1"
-                     },
-    "devDependencies":  {
-                            "prisma":  "6.17.1",
-                            "typescript":  "^5.9.3"
-                        },
-    "exports":  {
-                    ".":  "./src/index.ts",
-                    "./db":  "./src/db.ts",
-                    "./masking":  "./src/masking.ts"
-                }
+  "name": "@apgms/shared",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
+    "build": "echo building shared"
+  },
+  "dependencies": {
+    "@prisma/client": "6.17.1",
+    "pino": "^9.5.0"
+  },
+  "devDependencies": {
+    "prisma": "6.17.1",
+    "typescript": "^5.9.3"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./db": "./src/db.ts",
+    "./masking": "./src/masking.ts",
+    "./logging": "./src/logging.ts"
+  }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿export * from "./masking";
+export * from "./masking";
+export * from "./logging";

--- a/shared/src/logging.ts
+++ b/shared/src/logging.ts
@@ -1,0 +1,12 @@
+import pino from "pino";
+
+export const logger = pino({ level: process.env.LOG_LEVEL || "info" });
+
+export function withRedaction(payload: any) {
+  const clone = JSON.parse(JSON.stringify(payload || {}));
+  if (clone.email) clone.email = "***redacted***";
+  if (clone.phone) clone.phone = "***redacted***";
+  if (clone.bsb) clone.bsb = "***";
+  if (clone.account) clone.account = "****";
+  return clone;
+}


### PR DESCRIPTION
## Summary
- add a shared pino logger with built-in field redaction helpers
- emit append-only audit events for admin deletion and PII operations using correlation IDs
- document the audit log storage strategy and on-call review steps

## Testing
- pnpm -F @apgms/api-gateway add pino pino-pretty *(fails: registry returned 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a4bc5db88327888b63122106a2e2