### PR TITLE
Hash user credentials with Argon2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@fastify/cors": "^11.1.0",
     "@prisma/client": "6.17.1",
+    "argon2": "^0.41.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"
   }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,25 +1,55 @@
-﻿import { prisma } from "@apgms/shared/db";
-
+import argon2 from "argon2";
+import { prisma } from "@apgms/shared/db";
 
 async function main() {
   const org = await prisma.org.upsert({
-    where: { id: "demo-org" },
+    where: { id: "demo" },
     update: {},
-    create: { id: "demo-org", name: "Demo Org" },
+    create: { id: "demo", name: "Demo Org" },
   });
 
+  const adminPassword = process.env.SEED_ADMIN_PASSWORD;
+  if (!adminPassword) {
+    throw new Error("SEED_ADMIN_PASSWORD env var must be set");
+  }
+
+  const hash = await argon2.hash(adminPassword, { type: argon2.argon2id });
+
   await prisma.user.upsert({
-    where: { email: "founder@example.com" },
-    update: {},
-    create: { email: "founder@example.com", password: "password123", orgId: org.id },
+    where: { email: "admin@apgms.local" },
+    update: { passwordHash: hash, roles: ["admin"], orgId: org.id },
+    create: {
+      email: "admin@apgms.local",
+      passwordHash: hash,
+      roles: ["admin"],
+      orgId: org.id,
+    },
   });
 
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2),
+        amount: 1250.75,
+        payee: "Acme",
+        desc: "Office fit-out",
+      },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1),
+        amount: -299.99,
+        payee: "CloudCo",
+        desc: "Monthly sub",
+      },
+      {
+        orgId: org.id,
+        date: today,
+        amount: 5000.0,
+        payee: "Birchal",
+        desc: "Investment received",
+      },
     ],
     skipDuplicates: true,
   });
@@ -27,6 +57,11 @@ async function main() {
   console.log("Seed OK");
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
-
+main()
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -11,6 +11,7 @@
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
     "@prisma/client": "6.17.1",
+    "argon2": "^0.41.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"

--- a/services/api-gateway/src/routes/admin.data.ts
+++ b/services/api-gateway/src/routes/admin.data.ts
@@ -188,7 +188,7 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
         where: { id: subject.id },
         data: {
           email: anonymizedEmail,
-          password: PASSWORD_PLACEHOLDER,
+          passwordHash: PASSWORD_PLACEHOLDER,
         },
       });
 

--- a/services/api-gateway/src/services/users/create.ts
+++ b/services/api-gateway/src/services/users/create.ts
@@ -1,0 +1,18 @@
+import argon2 from "argon2";
+import type { Prisma } from "@prisma/client";
+
+import { prisma } from "@apgms/shared/db";
+
+type CreateUserInput = Omit<Prisma.UserCreateInput, "passwordHash"> & { password: string };
+
+export async function createUser(input: CreateUserInput) {
+  const { password, ...data } = input;
+  const hash = await argon2.hash(password, { type: argon2.argon2id });
+
+  return prisma.user.create({
+    data: {
+      ...data,
+      passwordHash: hash,
+    },
+  });
+}

--- a/services/api-gateway/test/admin.data.delete.spec.ts
+++ b/services/api-gateway/test/admin.data.delete.spec.ts
@@ -16,7 +16,8 @@ process.env.SHADOW_DATABASE_URL ??= "postgresql://user:pass@localhost:5432/test-
 type PrismaUser = {
   id: string;
   email: string;
-  password: string | null;
+  passwordHash: string | null;
+  roles: string[];
   createdAt: Date;
   orgId: string;
 };
@@ -130,7 +131,8 @@ describe("POST /admin/data/delete", () => {
     const user: PrismaUser = {
       id: "user-1",
       email: defaultPayload.email,
-      password: "secret",
+      passwordHash: "secret",
+      roles: ["member"],
       createdAt: new Date(),
       orgId: defaultPayload.orgId,
     };
@@ -185,7 +187,7 @@ describe("POST /admin/data/delete", () => {
     assert.equal(updateCalls.length, 1);
     const updateArgs = updateCalls[0];
     assert.match(updateArgs.data.email, /^deleted\+[a-f0-9]{12}@example.com$/);
-    assert.equal(updateArgs.data.password, "__deleted__");
+    assert.equal(updateArgs.data.passwordHash, "__deleted__");
 
     const lastLog = securityLogs.at(-1);
     assert.deepEqual(lastLog, {
@@ -201,7 +203,8 @@ describe("POST /admin/data/delete", () => {
     const user: PrismaUser = {
       id: "user-2",
       email: defaultPayload.email,
-      password: "secret",
+      passwordHash: "secret",
+      roles: ["member"],
       createdAt: new Date(),
       orgId: defaultPayload.orgId,
     };

--- a/services/api-gateway/test/password.spec.ts
+++ b/services/api-gateway/test/password.spec.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import argon2 from "argon2";
+
+test("hashing uses argon2id", async () => {
+  const hash = await argon2.hash("secret", { type: argon2.argon2id });
+  assert.equal(await argon2.verify(hash, "secret"), true);
+});

--- a/services/api-gateway/test/privacy.spec.ts
+++ b/services/api-gateway/test/privacy.spec.ts
@@ -224,7 +224,8 @@ function seedOrgWithData(state: State, ids: { orgId: string; userId: string; lin
   state.users.push({
     id: ids.userId,
     email: "someone@example.com",
-    password: "hashed-password",
+    passwordHash: "hashed-password",
+    roles: ["member"],
     orgId: ids.orgId,
     createdAt,
   } as User);

--- a/shared/prisma/migrations/20251010133921_init/migration.sql
+++ b/shared/prisma/migrations/20251010133921_init/migration.sql
@@ -11,7 +11,8 @@ CREATE TABLE "Org" (
 CREATE TABLE "User" (
     "id" TEXT NOT NULL,
     "email" TEXT NOT NULL,
-    "password" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "roles" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "orgId" TEXT NOT NULL,
 

--- a/shared/prisma/schema.prisma
+++ b/shared/prisma/schema.prisma
@@ -19,12 +19,13 @@ model Org {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  password  String
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
+  id           String   @id @default(cuid())
+  email        String   @unique
+  passwordHash String
+  roles        String[] @default([])
+  createdAt    DateTime @default(now())
+  org          Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId        String
 }
 
 model BankLine {


### PR DESCRIPTION
## Summary
- add the argon2 dependency for the workspace and API gateway service
- hash the seeded admin credential with Argon2id and ensure new user creation stores password hashes
- update the Prisma user model, related tests, and add a hashing unit test covering Argon2id usage

## Testing
- pnpm -F @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f7a46961008327b9b59f194daea156