### PR TITLE
feat(api-gateway): add org-scoped jwt auth guards

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -13,6 +13,8 @@
     "@prisma/client": "6.17.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "fastify-plugin": "^5.1.0",
+    "jose": "^5.9.6",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/services/api-gateway/src/app.ts
+++ b/services/api-gateway/src/app.ts
@@ -1,14 +1,20 @@
-﻿import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
+import Fastify, { type FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
 import { z } from "zod";
 import { Prisma, type Org, type User, type BankLine, type PrismaClient } from "@prisma/client";
 
 import { maskError, maskObject } from "@apgms/shared";
 
-const ADMIN_HEADER = "x-admin-token";
+import authPlugin from "./plugins/auth";
 
 export interface CreateAppOptions {
   prisma?: PrismaClient;
+  auth?: {
+    jwksUrl?: string;
+    issuer?: string;
+    audience?: string;
+    verify?: (token: string) => Promise<{ payload: Record<string, unknown> }>;
+  };
 }
 
 export interface AdminOrgExport {
@@ -52,8 +58,8 @@ async function loadDefaultPrisma(): Promise<PrismaLike> {
 
 /** Zod body schema for creating a bank line */
 const CreateLine = z.object({
-  date: z.string().datetime(),                     // ISO 8601 string
-  amount: z.string().regex(/^-?\d+(\.\d+)?$/),     // decimal as string
+  date: z.string().datetime(), // ISO 8601 string
+  amount: z.string().regex(/^-?\d+(\.\d+)?$/), // decimal as string
   payee: z.string().min(1),
   desc: z.string().min(1),
   orgId: z.string().min(1),
@@ -64,6 +70,15 @@ export async function createApp(options: CreateAppOptions = {}): Promise<Fastify
 
   const app = Fastify({ logger: true });
   app.register(cors, { origin: true });
+
+  const authConfig = {
+    jwksUrl: options.auth?.jwksUrl ?? process.env.JWKS_URL ?? "http://localhost/.well-known/jwks.json",
+    issuer: options.auth?.issuer ?? process.env.JWT_ISSUER ?? "test-issuer",
+    audience: options.auth?.audience ?? process.env.JWT_AUDIENCE ?? "test-audience",
+    verify: options.auth?.verify,
+  } as const;
+
+  await app.register(authPlugin, authConfig);
 
   app.log.info(maskObject({ DATABASE_URL: process.env.DATABASE_URL }), "loaded env");
 
@@ -80,161 +95,190 @@ export async function createApp(options: CreateAppOptions = {}): Promise<Fastify
     }
   });
 
-  app.get("/users", async () => {
-    const users = await prisma.user.findMany({
-      select: { email: true, orgId: true, createdAt: true },
-      orderBy: { createdAt: "desc" },
-    });
-    return { users };
-  });
+  app.get(
+    "/users",
+    { preHandler: app.authenticate },
+    async (req) => {
+      const { orgId } = req.auth!;
+      const users = await prisma.user.findMany({
+        where: { orgId },
+        select: { email: true, orgId: true, createdAt: true },
+        orderBy: { createdAt: "desc" },
+      });
+      return { users };
+    },
+  );
 
-  app.get("/bank-lines", async (req) => {
-    const take = Number((req.query as any).take ?? 20);
-    const lines = await prisma.bankLine.findMany({
-      orderBy: { date: "desc" },
-      take: Math.min(Math.max(take, 1), 200),
-    });
-    return { lines };
-  });
+  app.get(
+    "/bank-lines",
+    { preHandler: app.authenticate },
+    async (req) => {
+      const { orgId } = req.auth!;
+      const take = Number((req.query as any).take ?? 20);
+      const lines = await prisma.bankLine.findMany({
+        where: { orgId },
+        orderBy: { date: "desc" },
+        take: Math.min(Math.max(take, 1), 200),
+      });
+      return { lines };
+    },
+  );
 
   // --- Validated + idempotent create ---
-  app.post("/bank-lines", async (req, reply) => {
-    const parsed = CreateLine.safeParse(req.body);
-    if (!parsed.success) {
-      return reply.code(400).send({ error: "invalid_body", details: parsed.error.flatten() });
-    }
+  app.post(
+    "/bank-lines",
+    { preHandler: [app.authenticate, app.requireRole(["admin", "manager"])] },
+    async (req, reply) => {
+      const parsed = CreateLine.safeParse(req.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: "invalid_body", details: parsed.error.flatten() });
+      }
 
-    const { orgId, date, amount, payee, desc } = parsed.data;
-    const keyHeader = (req.headers["idempotency-key"] as string | undefined)?.trim();
-    const idemKey = keyHeader && keyHeader.length > 0 ? keyHeader : undefined;
+      const { orgId, date, amount, payee, desc } = parsed.data;
+      const authOrgId = req.auth!.orgId;
 
-    try {
-      if (idemKey) {
-        // Upsert on the compound unique key @@unique([orgId, idempotencyKey])
-        const line = await prisma.bankLine.upsert({
-          where: { orgId_idempotencyKey: { orgId, idempotencyKey: idemKey } },
-          create: {
-            orgId,
+      if (orgId !== authOrgId) {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+
+      const keyHeader = (req.headers["idempotency-key"] as string | undefined)?.trim();
+      const idemKey = keyHeader && keyHeader.length > 0 ? keyHeader : undefined;
+
+      try {
+        if (idemKey) {
+          // Upsert on the compound unique key @@unique([orgId, idempotencyKey])
+          const line = await prisma.bankLine.upsert({
+            where: { orgId_idempotencyKey: { orgId: authOrgId, idempotencyKey: idemKey } },
+            create: {
+              orgId: authOrgId,
+              date: new Date(date),
+              amount: new Prisma.Decimal(amount),
+              payee,
+              desc,
+              idempotencyKey: idemKey,
+            },
+            update: {}, // replay → no-op
+            select: {
+              id: true,
+              orgId: true,
+              date: true,
+              amount: true,
+              payee: true,
+              desc: true,
+              createdAt: true,
+              idempotencyKey: true,
+            },
+          });
+
+          reply.header("Idempotency-Status", "reused");
+          return reply.code(200).send(line);
+        }
+
+        // No idempotency key → plain create
+        const created = await prisma.bankLine.create({
+          data: {
+            orgId: authOrgId,
             date: new Date(date),
             amount: new Prisma.Decimal(amount),
             payee,
             desc,
-            idempotencyKey: idemKey,
           },
-          update: {}, // replay → no-op
           select: {
-            id: true, orgId: true, date: true, amount: true, payee: true, desc: true, createdAt: true, idempotencyKey: true
+            id: true,
+            orgId: true,
+            date: true,
+            amount: true,
+            payee: true,
+            desc: true,
+            createdAt: true,
+            idempotencyKey: true,
           },
         });
 
-        reply.header("Idempotency-Status", "reused");
-        return reply.code(200).send(line);
+        return reply.code(201).send(created);
+      } catch (e) {
+        // If a race slipped through, surface an idempotency-ish signal
+        req.log.error({ err: maskError(e) }, "failed to create bank line");
+        return reply.code(400).send({ error: "bad_request" });
       }
-
-      // No idempotency key → plain create
-      const created = await prisma.bankLine.create({
-        data: {
-          orgId,
-          date: new Date(date),
-          amount: new Prisma.Decimal(amount),
-          payee,
-          desc,
-        },
-        select: {
-          id: true, orgId: true, date: true, amount: true, payee: true, desc: true, createdAt: true, idempotencyKey: true
-        },
-      });
-
-      return reply.code(201).send(created);
-    } catch (e) {
-      // If a race slipped through, surface an idempotency-ish signal
-      req.log.error({ err: maskError(e) }, "failed to create bank line");
-      return reply.code(400).send({ error: "bad_request" });
-    }
-  });
+    },
+  );
   // --- /validated + idempotent create ---
 
-  app.get("/admin/export/:orgId", async (req, rep) => {
-    if (!requireAdmin(req, rep)) {
-      return;
-    }
-    const { orgId } = req.params as { orgId: string };
-    const org = await prisma.org.findUnique({
-      where: { id: orgId },
-      include: { users: true, lines: true },
-    });
-    if (!org) {
-      return rep.code(404).send({ error: "org_not_found" });
-    }
+  app.get(
+    "/admin/export/:orgId",
+    { preHandler: [app.authenticate, app.requireRole(["admin"])] },
+    async (req, rep) => {
+      const { orgId } = req.params as { orgId: string };
 
-    const exportPayload = buildOrgExport(org as ExportableOrg);
-    return rep.send({ export: exportPayload });
-  });
+      if (req.auth!.orgId !== orgId) {
+        return rep.code(403).send({ error: "forbidden" });
+      }
 
-  app.delete("/admin/delete/:orgId", async (req, rep) => {
-    if (!requireAdmin(req, rep)) {
-      return;
-    }
-    const { orgId } = req.params as { orgId: string };
-    const org = await prisma.org.findUnique({
-      where: { id: orgId },
-      include: { users: true, lines: true },
-    });
-    if (!org) {
-      return rep.code(404).send({ error: "org_not_found" });
-    }
-    if (org.deletedAt) {
-      return rep.code(409).send({ error: "already_deleted" });
-    }
-
-    const exportPayload = buildOrgExport(org as ExportableOrg);
-    const deletedAt = new Date();
-    const tombstonePayload: AdminOrgExport = {
-      ...exportPayload,
-      org: { ...exportPayload.org, deletedAt: deletedAt.toISOString() },
-    };
-
-    await prisma.$transaction(async (tx) => {
-      await tx.org.update({
+      const org = await prisma.org.findUnique({
         where: { id: orgId },
-        data: { deletedAt },
+        include: { users: true, lines: true },
       });
-      await tx.user.deleteMany({ where: { orgId } });
-      await tx.bankLine.deleteMany({ where: { orgId } });
-      await tx.orgTombstone.create({
-        data: {
-          orgId,
-          payload: tombstonePayload,
-        },
-      });
-    });
+      if (!org) {
+        return rep.code(404).send({ error: "org_not_found" });
+      }
 
-    return rep.send({ status: "deleted", deletedAt: deletedAt.toISOString() });
-  });
+      const exportPayload = buildOrgExport(org as ExportableOrg);
+      return rep.send({ export: exportPayload });
+    },
+  );
+
+  app.delete(
+    "/admin/delete/:orgId",
+    { preHandler: [app.authenticate, app.requireRole(["admin"])] },
+    async (req, rep) => {
+      const { orgId } = req.params as { orgId: string };
+
+      if (req.auth!.orgId !== orgId) {
+        return rep.code(403).send({ error: "forbidden" });
+      }
+      const org = await prisma.org.findUnique({
+        where: { id: orgId },
+        include: { users: true, lines: true },
+      });
+      if (!org) {
+        return rep.code(404).send({ error: "org_not_found" });
+      }
+      if (org.deletedAt) {
+        return rep.code(409).send({ error: "already_deleted" });
+      }
+
+      const exportPayload = buildOrgExport(org as ExportableOrg);
+      const deletedAt = new Date();
+      const tombstonePayload: AdminOrgExport = {
+        ...exportPayload,
+        org: { ...exportPayload.org, deletedAt: deletedAt.toISOString() },
+      };
+
+      await prisma.$transaction(async (tx) => {
+        await tx.org.update({
+          where: { id: orgId },
+          data: { deletedAt },
+        });
+        await tx.user.deleteMany({ where: { orgId } });
+        await tx.bankLine.deleteMany({ where: { orgId } });
+        await tx.orgTombstone.create({
+          data: {
+            orgId,
+            payload: tombstonePayload,
+          },
+        });
+      });
+
+      return rep.send({ status: "deleted", deletedAt: deletedAt.toISOString() });
+    },
+  );
 
   app.ready(() => {
     app.log.info(app.printRoutes());
   });
 
   return app;
-}
-
-function requireAdmin(req: FastifyRequest, rep: FastifyReply): boolean {
-  const configuredToken = process.env.ADMIN_TOKEN;
-  if (!configuredToken) {
-    req.log.error("ADMIN_TOKEN is not configured");
-    void rep.code(500).send({ error: "admin_config_missing" });
-    return false;
-  }
-
-  const provided = req.headers[ADMIN_HEADER] ?? req.headers[ADMIN_HEADER.toUpperCase() as keyof typeof req.headers];
-  const providedValue = Array.isArray(provided) ? provided[0] : provided;
-
-  if (providedValue !== configuredToken) {
-    void rep.code(403).send({ error: "forbidden" });
-    return false;
-  }
-  return true;
 }
 
 function buildOrgExport(org: ExportableOrg): AdminOrgExport {

--- a/services/api-gateway/src/plugins/auth.ts
+++ b/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,80 @@
+import fp from "fastify-plugin";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { JWTPayload, JWTVerifyResult } from "jose";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+export type Role = "admin" | "manager" | "analyst" | "viewer";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    auth?: { sub: string; orgId: string; roles: Role[] };
+  }
+}
+
+interface Opts {
+  jwksUrl: string;
+  issuer: string;
+  audience: string;
+  verify?: (token: string) => Promise<Pick<JWTVerifyResult, "payload">>;
+}
+
+export default fp<Opts>(async (app, opts) => {
+  const JWKS = opts.verify ? undefined : createRemoteJWKSet(new URL(opts.jwksUrl));
+
+  const verifyToken = opts.verify
+    ? opts.verify
+    : (token: string) => jwtVerify(token, JWKS!, { issuer: opts.issuer, audience: opts.audience });
+
+  app.decorate("authenticate", async (req: FastifyRequest, reply: FastifyReply) => {
+    try {
+      const hdr = req.headers.authorization ?? "";
+      const token = hdr.startsWith("Bearer ") ? hdr.slice(7) : undefined;
+      if (!token) {
+        await reply.code(401).send({ error: "Unauthorized" });
+        return reply;
+      }
+
+      const { payload } = await verifyToken(token);
+      const payloadData = payload as JWTPayload & {
+        orgId?: string;
+        roles?: Role[];
+      };
+
+      const orgId = payloadData.orgId ?? "";
+      if (!orgId) {
+        await reply.code(401).send({ error: "Unauthorized" });
+        return reply;
+      }
+
+      const roles = Array.isArray(payloadData.roles) ? payloadData.roles : [];
+
+      req.auth = {
+        sub: String(payloadData.sub ?? ""),
+        orgId: String(orgId),
+        roles: roles.map((role) => role),
+      };
+    } catch {
+      await reply.code(401).send({ error: "Unauthorized" });
+      return reply;
+    }
+  });
+
+  app.decorate("requireRole", (roles: Role[]) => {
+    return async (req: FastifyRequest, reply: FastifyReply) => {
+      const hasRole =
+        req.auth !== undefined && req.auth.roles.some((role) => roles.includes(role));
+
+      if (!hasRole) {
+        await reply.code(403).send({ error: "Forbidden" });
+        return reply;
+      }
+    };
+  });
+});
+
+declare module "fastify" {
+  interface FastifyInstance {
+    authenticate: (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    requireRole: (roles: Role[]) => (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  }
+}

--- a/services/api-gateway/src/schemas/admin.data.ts
+++ b/services/api-gateway/src/schemas/admin.data.ts
@@ -1,6 +1,5 @@
-﻿import { z } from "zod";
+import { z } from "zod";
 
-<<<<<<< HEAD
 export const adminDataDeleteRequestSchema = z.object({
   orgId: z.string().min(1, "orgId is required"),
   email: z.string().email("email must be valid"),
@@ -19,7 +18,7 @@ export const adminDataDeleteResponseSchema = z.object({
 
 export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
 export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
-=======
+
 export const subjectDataExportRequestSchema = z.object({
   orgId: z.string().min(1),
   email: z.string().email(),
@@ -47,12 +46,5 @@ export const subjectDataExportResponseSchema = z.object({
   exportedAt: z.string(),
 });
 
-export type SubjectDataExportRequest = z.infer<
-  typeof subjectDataExportRequestSchema
->;
-
-export type SubjectDataExportResponse = z.infer<
-  typeof subjectDataExportResponseSchema
->;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-
+export type SubjectDataExportRequest = z.infer<typeof subjectDataExportRequestSchema>;
+export type SubjectDataExportResponse = z.infer<typeof subjectDataExportResponseSchema>;

--- a/services/api-gateway/test/auth.spec.ts
+++ b/services/api-gateway/test/auth.spec.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildApp } from "./test-utils";
+
+const defaultPayload = {
+  orgId: "org-123",
+  date: new Date("2024-01-01T00:00:00.000Z").toISOString(),
+  amount: "42.00",
+  payee: "Example",
+  desc: "Example line",
+};
+
+test("unauthenticated requests receive 401", async () => {
+  const app = await buildApp();
+
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+
+  assert.equal(response.statusCode, 401);
+
+  await app.close();
+});
+
+test("principals without role receive 403", async () => {
+  const app = await buildApp({ tokenRole: "viewer" });
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: { ...defaultPayload },
+    headers: { authorization: "Bearer TEST_VIEWER" },
+  });
+
+  assert.equal(response.statusCode, 403);
+
+  await app.close();
+});

--- a/services/api-gateway/test/test-utils.ts
+++ b/services/api-gateway/test/test-utils.ts
@@ -1,0 +1,98 @@
+import type { Role } from "../src/plugins/auth";
+import { createApp } from "../src/app";
+
+const buildPrismaStub = (orgId: string) => {
+  const line = {
+    id: "line-1",
+    orgId,
+    date: new Date("2024-01-01T00:00:00.000Z"),
+    amount: 0,
+    payee: "example",
+    desc: "example",
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    idempotencyKey: null as string | null,
+  };
+
+  const txClient = {
+    org: { update: async () => ({}) },
+    user: { deleteMany: async () => ({}) },
+    bankLine: { deleteMany: async () => ({}) },
+    orgTombstone: { create: async () => ({}) },
+  };
+
+  return {
+    $queryRaw: async () => 1,
+    $transaction: async (fn: (tx: typeof txClient) => unknown | Promise<unknown>) =>
+      await Promise.resolve(fn(txClient)),
+    org: { findUnique: async () => null },
+    orgTombstone: { create: async () => ({}) },
+    user: { findMany: async () => [] },
+    bankLine: {
+      findMany: async () => [],
+      upsert: async () => line,
+      create: async () => line,
+      deleteMany: async () => ({}),
+    },
+  } as const;
+};
+
+type TokenPayload = { sub: string; orgId: string; roles: Role[] };
+
+interface BuildAppOptions {
+  tokenRole?: Role;
+  tokenOrgId?: string;
+  tokenSub?: string;
+  tokens?: Array<{ token: string; payload: TokenPayload }>;
+}
+
+const buildDefaultTokens = (orgId: string, sub: string): Array<{ token: string; payload: TokenPayload }> => {
+  const roles: Role[] = ["admin", "manager", "analyst", "viewer"];
+  return roles.map((role) => ({
+    token: `TEST_${role.toUpperCase()}`,
+    payload: { sub: `${sub}-${role}`, orgId, roles: [role] },
+  }));
+};
+
+export async function buildApp(options: BuildAppOptions = {}) {
+  const orgId = options.tokenOrgId ?? "org-123";
+  const sub = options.tokenSub ?? "user-123";
+
+  const tokenEntries = new Map<string, TokenPayload>();
+
+  for (const entry of buildDefaultTokens(orgId, sub)) {
+    tokenEntries.set(entry.token, entry.payload);
+  }
+
+  if (options.tokenRole) {
+    tokenEntries.set(`TEST_${options.tokenRole.toUpperCase()}`, {
+      sub,
+      orgId,
+      roles: [options.tokenRole],
+    });
+  }
+
+  for (const entry of options.tokens ?? []) {
+    tokenEntries.set(entry.token, entry.payload);
+  }
+
+  const verify = async (token: string) => {
+    const payload = tokenEntries.get(token);
+    if (!payload) {
+      throw new Error("invalid token");
+    }
+    return { payload };
+  };
+
+  const app = await createApp({
+    prisma: buildPrismaStub(orgId) as any,
+    auth: {
+      jwksUrl: "http://localhost/.well-known/jwks.json",
+      issuer: "test-issuer",
+      audience: "test-audience",
+      verify,
+    },
+  });
+
+  await app.ready();
+  return app;
+}


### PR DESCRIPTION
## Summary
- add a reusable Fastify auth plugin that verifies JWTs via remote JWKS and exposes authentication/role guards
- register the plugin in the API gateway, scope queries by org, and gate external/admin routes by role
- add lightweight auth test utilities and cover unauthorized and forbidden flows

## Testing
- `pnpm exec tsx --test test/auth.spec.ts` *(fails: missing fastify-plugin/jose packages in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7a43a4b6083279d11bd9b0ae21546