### PR TITLE
feat(api-gateway): bootstrap AWS-backed PII providers

### DIFF
--- a/runbooks/pii-rotation.md
+++ b/runbooks/pii-rotation.md
@@ -1,0 +1,61 @@
+# PII key and salt rotation
+
+This runbook documents how to rotate the encryption materials that back the API
+Gateway PII utilities (`encryptPII`, `decryptPII`, and `tokenizeTFN`). The
+application loads a KMS-backed AES key and a Secrets Manager salt during
+bootstrap via the `bootstrapPII` helper.
+
+## Prerequisites
+
+* AWS credentials with permissions for KMS `Decrypt`, `GenerateDataKey`, and
+  Secrets Manager `GetSecretValue`/`PutSecretValue`.
+* The current environment variables:
+  * `PII_KMS_KEYS` – JSON array of KMS-encrypted data keys.
+  * `PII_KMS_ACTIVE_KEY_ID` – the key identifier that should be used for new
+    encrypt operations.
+  * `PII_SALT_SECRETS` – JSON array mapping salt identifiers to Secrets Manager
+    secret IDs.
+  * `PII_SALT_ACTIVE_ID` – the salt identifier used when tokenising TFNs.
+
+## Rotation steps
+
+1. **Generate a new data key**
+   1. Run `aws kms generate-data-key --key-id <customer-master-key>` with
+      `--key-spec AES_256`.
+   2. Capture both the `CiphertextBlob` (base64) and the plaintext key (also
+      base64). Store the plaintext key in a secure vault until the rollout
+      completes.
+2. **Create the new salt secret**
+   1. Generate 32 bytes of random data: `openssl rand -base64 32`.
+   2. Store the base64 string as a new Secrets Manager secret JSON payload in
+      the shape `{ "value": "<base64-string>" }`.
+3. **Update application configuration**
+   1. Append the new data key entry to `PII_KMS_KEYS`, e.g.
+      ```json
+      [{ "kid": "pii-key-v2", "ciphertext": "<CiphertextBlob>" }]
+      ```
+   2. Set `PII_KMS_ACTIVE_KEY_ID=pii-key-v2`.
+   3. Append the new salt definition to `PII_SALT_SECRETS`, e.g.
+      ```json
+      [{ "sid": "salt-v2", "secretId": "arn:aws:secrets:..." }]
+      ```
+   4. Set `PII_SALT_ACTIVE_ID=salt-v2`.
+4. **Deploy** – roll out the environment variables alongside the application
+   release. The bootstrapper logs `pii providers initialised` with the active
+   key/salt identifiers when successful.
+5. **Validate**
+   1. Run the API Gateway `pnpm test` suite or the CI pipeline to execute the
+      PII integration test, which performs an encrypt/decrypt round-trip using
+      the configured providers.
+   2. Exercise `/admin/pii/decrypt` with a test payload and verify that the
+      audit log contains the `pii.decrypt` entry.
+6. **Clean up** – once no ciphertexts remain for the previous key/salt, remove
+   the old entries from `PII_KMS_KEYS`/`PII_SALT_SECRETS` and delete the retired
+   Secrets Manager secret.
+
+## Rollback
+
+If decryption fails after the rotation, revert `PII_KMS_ACTIVE_KEY_ID` and
+`PII_SALT_ACTIVE_ID` to their previous values. Because the historical entries
+remain in `PII_KMS_KEYS` and `PII_SALT_SECRETS`, the application can continue to
+resolve old identifiers.

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
+    "@aws-sdk/client-kms": "^3.726.1",
+    "@aws-sdk/client-secrets-manager": "^3.726.1",
     "@fastify/cors": "^11.1.0",
     "@prisma/client": "6.17.1",
     "dotenv": "^16.6.1",

--- a/services/api-gateway/src/lib/admin-auth.ts
+++ b/services/api-gateway/src/lib/admin-auth.ts
@@ -1,0 +1,68 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import type { AdminGuard, AdminGuardResult } from "./pii";
+
+export const ADMIN_TOKEN_HEADER = "x-admin-token";
+
+export interface AdminVerificationResult extends AdminGuardResult {}
+
+function normaliseHeader(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (Array.isArray(value)) {
+    return value.length > 0 ? String(value[0]) : undefined;
+  }
+  return String(value);
+}
+
+function computeActorId(token: string): string {
+  const digest = createHash("sha256").update(token).digest("base64url");
+  return `admin:${digest.slice(0, 16)}`;
+}
+
+export function verifySignedAdmin(request: FastifyRequest): AdminVerificationResult {
+  const configuredToken = process.env.ADMIN_TOKEN;
+  if (!configuredToken) {
+    return { allowed: false, actorId: "unknown", reason: "missing_config" };
+  }
+
+  const providedHeader =
+    request.headers[ADMIN_TOKEN_HEADER] ??
+    request.headers[ADMIN_TOKEN_HEADER.toUpperCase() as keyof typeof request.headers];
+  const provided = normaliseHeader(providedHeader)?.trim();
+
+  if (!provided) {
+    return { allowed: false, actorId: "unknown", reason: "unauthorized" };
+  }
+
+  const expectedBuffer = Buffer.from(configuredToken, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return { allowed: false, actorId: "unknown", reason: "unauthorized" };
+  }
+
+  if (!timingSafeEqual(expectedBuffer, providedBuffer)) {
+    return { allowed: false, actorId: "unknown", reason: "unauthorized" };
+  }
+
+  return { allowed: true, actorId: computeActorId(configuredToken) };
+}
+
+export function requireSignedAdmin(req: FastifyRequest, rep: FastifyReply): boolean {
+  const decision = verifySignedAdmin(req);
+  if (!decision.allowed) {
+    if (decision.reason === "missing_config") {
+      req.log.error("ADMIN_TOKEN is not configured");
+      void rep.code(500).send({ error: "admin_config_missing" });
+    } else {
+      void rep.code(403).send({ error: "forbidden" });
+    }
+    return false;
+  }
+  return true;
+}
+
+export function createSignedAdminGuard(): AdminGuard {
+  return (request) => verifySignedAdmin(request);
+}

--- a/services/api-gateway/src/lib/pii-bootstrap.ts
+++ b/services/api-gateway/src/lib/pii-bootstrap.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance } from "fastify";
+
+import { configurePIIProviders, registerPIIRoutes, type AuditLogger } from "./pii";
+import { createSignedAdminGuard } from "./admin-auth";
+import {
+  createAwsKmsKeyManagementService,
+  type AwsKmsClientLike,
+  type AwsKmsKeyDefinition,
+} from "./providers/aws-kms";
+import {
+  createSecretsManagerSaltProvider,
+  type SecretSaltDefinition,
+  type SecretsManagerClientLike,
+} from "./providers/secrets-manager";
+
+interface PiiBootstrapOptions {
+  kmsClient?: AwsKmsClientLike;
+  secretsClient?: SecretsManagerClientLike;
+  auditLogger?: AuditLogger;
+  region?: string;
+}
+
+function parseJson<T>(value: string, name: string): T {
+  try {
+    const parsed = JSON.parse(value) as T;
+    return parsed;
+  } catch (error) {
+    throw new Error(`Failed to parse ${name}: ${(error as Error).message}`);
+  }
+}
+
+export async function bootstrapPII(app: FastifyInstance, options: PiiBootstrapOptions = {}): Promise<void> {
+  const kmsActiveKeyId = process.env.PII_KMS_ACTIVE_KEY_ID;
+  const kmsKeyRingRaw = process.env.PII_KMS_KEYS;
+  const saltActiveId = process.env.PII_SALT_ACTIVE_ID;
+  const saltSecretsRaw = process.env.PII_SALT_SECRETS;
+
+  if (!kmsActiveKeyId || !kmsKeyRingRaw || !saltActiveId || !saltSecretsRaw) {
+    app.log.warn("PII providers not fully configured; skipping bootstrap");
+    return;
+  }
+
+  const kmsKeyRing = parseJson<AwsKmsKeyDefinition[]>(kmsKeyRingRaw, "PII_KMS_KEYS");
+  const saltSecrets = parseJson<SecretSaltDefinition[]>(saltSecretsRaw, "PII_SALT_SECRETS");
+
+  const region = options.region ?? process.env.AWS_REGION;
+
+  const [kms, saltProvider] = await Promise.all([
+    createAwsKmsKeyManagementService({
+      client: options.kmsClient,
+      keys: kmsKeyRing,
+      activeKeyId: kmsActiveKeyId,
+      region,
+    }),
+    createSecretsManagerSaltProvider({
+      client: options.secretsClient,
+      secrets: saltSecrets,
+      activeSaltId: saltActiveId,
+      region,
+    }),
+  ]);
+
+  const auditLogger: AuditLogger =
+    options.auditLogger ??
+    ({
+      record: async (event) => {
+        app.log.info({ audit: event }, "pii_audit_event");
+      },
+    } satisfies AuditLogger);
+
+  configurePIIProviders({ kms, saltProvider, auditLogger });
+
+  const guard = createSignedAdminGuard();
+  registerPIIRoutes(app, guard);
+
+  app.log.info({ activeKey: kmsActiveKeyId, activeSalt: saltActiveId }, "pii providers initialised");
+}
+

--- a/services/api-gateway/src/lib/pii.ts
+++ b/services/api-gateway/src/lib/pii.ts
@@ -108,6 +108,7 @@ export function decryptPII(payload: { ciphertext: string; kid: string }): string
 export interface AdminGuardResult {
   allowed: boolean;
   actorId: string;
+  reason?: "missing_config" | "unauthorized";
 }
 
 export type AdminGuard = (request: FastifyRequest) => Promise<AdminGuardResult> | AdminGuardResult;
@@ -122,6 +123,9 @@ export function registerPIIRoutes(app: FastifyInstance, guard: AdminGuard): void
 
       const decision = await guard(request);
       if (!decision.allowed) {
+        if (decision.reason === "missing_config") {
+          return reply.code(500).send({ error: "admin_config_missing" });
+        }
         return reply.code(403).send({ error: "forbidden" });
       }
 

--- a/services/api-gateway/src/lib/providers/aws-kms.ts
+++ b/services/api-gateway/src/lib/providers/aws-kms.ts
@@ -1,0 +1,71 @@
+import { DecryptCommand, KMSClient } from "@aws-sdk/client-kms";
+
+import type { EncryptionKey, KeyManagementService } from "../pii";
+
+export interface AwsKmsClientLike {
+  send(command: DecryptCommand): Promise<{ Plaintext?: Uint8Array | undefined }>;
+}
+
+export interface AwsKmsKeyDefinition {
+  kid: string;
+  ciphertext: string;
+}
+
+export interface AwsKmsOptions {
+  client?: AwsKmsClientLike;
+  keys: AwsKmsKeyDefinition[];
+  activeKeyId: string;
+  region?: string;
+}
+
+export async function createAwsKmsKeyManagementService(options: AwsKmsOptions): Promise<KeyManagementService> {
+  const { keys, activeKeyId } = options;
+  if (!Array.isArray(keys) || keys.length === 0) {
+    throw new Error("No KMS keys configured");
+  }
+
+  const client = options.client ?? new KMSClient({ region: options.region });
+
+  const decryptedKeys = new Map<string, Buffer>();
+
+  for (const entry of keys) {
+    if (!entry?.kid || !entry?.ciphertext) {
+      throw new Error("Invalid KMS key definition");
+    }
+    const ciphertext = Buffer.from(entry.ciphertext, "base64");
+    const response = await client.send(
+      new DecryptCommand({
+        CiphertextBlob: ciphertext,
+      }),
+    );
+    if (!response.Plaintext) {
+      throw new Error(`KMS did not return plaintext for key ${entry.kid}`);
+    }
+    const material = Buffer.from(response.Plaintext);
+    if (material.length !== 32) {
+      throw new Error(`Invalid key length for ${entry.kid}; expected 32 bytes`);
+    }
+    decryptedKeys.set(entry.kid, material);
+  }
+
+  if (!decryptedKeys.has(activeKeyId)) {
+    throw new Error(`Active key ${activeKeyId} not present in decrypted key set`);
+  }
+
+  function getKeyById(kid: string): EncryptionKey | undefined {
+    const material = decryptedKeys.get(kid);
+    if (!material) return undefined;
+    return { kid, material };
+  }
+
+  return {
+    getActiveKey(): EncryptionKey {
+      const active = getKeyById(activeKeyId);
+      if (!active) {
+        throw new Error(`Active key ${activeKeyId} not loaded`);
+      }
+      return active;
+    },
+    getKeyById,
+  };
+}

--- a/services/api-gateway/src/lib/providers/secrets-manager.ts
+++ b/services/api-gateway/src/lib/providers/secrets-manager.ts
@@ -1,0 +1,83 @@
+import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+
+import type { SaltMaterial, TokenSaltProvider } from "../pii";
+
+export interface SecretsManagerClientLike {
+  send(command: GetSecretValueCommand): Promise<{ SecretString?: string; SecretBinary?: Uint8Array }>;
+}
+
+export interface SecretSaltDefinition {
+  sid: string;
+  secretId: string;
+}
+
+export interface SecretsManagerSaltOptions {
+  client?: SecretsManagerClientLike;
+  secrets: SecretSaltDefinition[];
+  activeSaltId: string;
+  region?: string;
+}
+
+export async function createSecretsManagerSaltProvider(
+  options: SecretsManagerSaltOptions,
+): Promise<TokenSaltProvider> {
+  const { secrets, activeSaltId } = options;
+  if (!Array.isArray(secrets) || secrets.length === 0) {
+    throw new Error("No token salts configured");
+  }
+
+  const client = options.client ?? new SecretsManagerClient({ region: options.region });
+  const loadedSalts = new Map<string, Buffer>();
+
+  for (const entry of secrets) {
+    if (!entry?.sid || !entry?.secretId) {
+      throw new Error("Invalid salt secret definition");
+    }
+
+    const response = await client.send(
+      new GetSecretValueCommand({
+        SecretId: entry.secretId,
+      }),
+    );
+
+    let secretValue: Buffer | undefined;
+    if (response.SecretBinary) {
+      secretValue = Buffer.from(response.SecretBinary);
+    } else if (response.SecretString) {
+      try {
+        const parsed = JSON.parse(response.SecretString) as { value?: string } | undefined;
+        const value = typeof parsed?.value === "string" ? parsed.value : response.SecretString;
+        secretValue = Buffer.from(value, "base64");
+      } catch {
+        secretValue = Buffer.from(response.SecretString, "base64");
+      }
+    }
+
+    if (!secretValue) {
+      throw new Error(`Secret ${entry.secretId} did not contain usable salt material`);
+    }
+
+    loadedSalts.set(entry.sid, secretValue);
+  }
+
+  if (!loadedSalts.has(activeSaltId)) {
+    throw new Error(`Active salt ${activeSaltId} not present in loaded secrets`);
+  }
+
+  function getSaltById(sid: string): SaltMaterial | undefined {
+    const secret = loadedSalts.get(sid);
+    if (!secret) return undefined;
+    return { sid, secret };
+  }
+
+  return {
+    getActiveSalt(): SaltMaterial {
+      const active = getSaltById(activeSaltId);
+      if (!active) {
+        throw new Error(`Active salt ${activeSaltId} not loaded`);
+      }
+      return active;
+    },
+    getSaltById,
+  };
+}

--- a/services/api-gateway/test/pii.integration.spec.ts
+++ b/services/api-gateway/test/pii.integration.spec.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { randomBytes } from "node:crypto";
+
+import type { DecryptCommand } from "@aws-sdk/client-kms";
+import type { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import type { FastifyInstance } from "fastify";
+
+import { createApp } from "../src/app";
+import { encryptPII } from "../src/lib/pii";
+import type { AwsKmsClientLike } from "../src/lib/providers/aws-kms";
+import type { SecretsManagerClientLike } from "../src/lib/providers/secrets-manager";
+import type { AuditEvent, AuditLogger } from "../src/lib/pii";
+
+class StubKmsClient implements AwsKmsClientLike {
+  constructor(private readonly keys: Map<string, Buffer>) {}
+
+  async send(command: DecryptCommand) {
+    const blob = command.input.CiphertextBlob;
+    if (!blob) {
+      throw new Error("CiphertextBlob missing");
+    }
+    const lookup = Buffer.from(blob as Uint8Array).toString("base64");
+    const material = this.keys.get(lookup);
+    if (!material) {
+      throw new Error(`Unknown ciphertext ${lookup}`);
+    }
+    return { Plaintext: material };
+  }
+}
+
+class StubSecretsClient implements SecretsManagerClientLike {
+  constructor(private readonly secrets: Map<string, Buffer>) {}
+
+  async send(command: GetSecretValueCommand) {
+    const id = command.input.SecretId;
+    if (!id) {
+      throw new Error("SecretId missing");
+    }
+    const value = this.secrets.get(id);
+    if (!value) {
+      throw new Error(`Secret ${id} not found`);
+    }
+    return { SecretString: JSON.stringify({ value: value.toString("base64") }) };
+  }
+}
+
+describe("PII bootstrap integration", () => {
+  const envKeys = [
+    "PII_KMS_ACTIVE_KEY_ID",
+    "PII_KMS_KEYS",
+    "PII_SALT_ACTIVE_ID",
+    "PII_SALT_SECRETS",
+    "ADMIN_TOKEN",
+  ] as const;
+
+  const previousEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+  let app: FastifyInstance;
+  let auditEvents: AuditEvent[];
+
+  beforeEach(async () => {
+    for (const key of envKeys) {
+      previousEnv[key] = process.env[key];
+    }
+
+    const encryptionKey = randomBytes(32);
+    const saltSecret = randomBytes(32);
+    const ciphertext = Buffer.from("test-ciphertext", "utf8");
+
+    const kmsClient = new StubKmsClient(new Map([[ciphertext.toString("base64"), encryptionKey]]));
+    const secretsClient = new StubSecretsClient(new Map([["arn:aws:secrets:region:acct:secret/pii", saltSecret]]));
+
+    process.env.PII_KMS_ACTIVE_KEY_ID = "pii-key-v1";
+    process.env.PII_KMS_KEYS = JSON.stringify([
+      { kid: "pii-key-v1", ciphertext: ciphertext.toString("base64") },
+    ]);
+    process.env.PII_SALT_ACTIVE_ID = "salt-v1";
+    process.env.PII_SALT_SECRETS = JSON.stringify([
+      { sid: "salt-v1", secretId: "arn:aws:secrets:region:acct:secret/pii" },
+    ]);
+    process.env.ADMIN_TOKEN = "signed-admin-token";
+
+    auditEvents = [];
+    const auditLogger: AuditLogger = {
+      record: async (event) => {
+        auditEvents.push(event);
+      },
+    };
+
+    app = await createApp({
+      pii: {
+        kmsClient,
+        secretsClient,
+        auditLogger,
+      },
+    });
+
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+    for (const key of envKeys) {
+      if (previousEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previousEnv[key];
+      }
+    }
+    auditEvents = [];
+  });
+
+  it("decrypts payloads using the configured AWS providers", async () => {
+    const secret = encryptPII("pii-payload");
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/pii/decrypt",
+      headers: { "x-admin-token": "signed-admin-token" },
+      payload: secret,
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { value: string };
+    assert.equal(body.value, "pii-payload");
+
+    assert.equal(auditEvents.length, 1);
+    assert.equal(auditEvents[0].action, "pii.decrypt");
+    assert.equal(auditEvents[0].actorId.startsWith("admin:"), true);
+    assert.equal(auditEvents[0].metadata?.kid, secret.kid);
+  });
+});


### PR DESCRIPTION
## Summary
- add AWS KMS and Secrets Manager adapters for the PII module and bootstrap them during app startup
- reuse the signed admin verifier for the /admin/pii/decrypt route so audit logs capture actor identifiers
- document rotation steps for keys and salts while adding an integration test that exercises encrypt/decrypt round-trips

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f79d5c616c83279ec3cda1224dc31f