### PR TITLE
feat: add pii key management and admin guard protections

### DIFF
--- a/docs/security/pii-key-management.md
+++ b/docs/security/pii-key-management.md
@@ -1,0 +1,46 @@
+# PII key management
+
+The API gateway consumes encryption keys and token salts from environment
+configuration so that decryption is only possible when the service is deployed
+with the correct secrets. The loader supports two delivery mechanisms:
+
+- **Direct base64 material** – the `material`/`secret` field is a base64 encoded
+  32 byte AES key or token salt.
+- **AWS KMS ciphertext** – the `ciphertext` field is a base64 encoded blob
+  produced by `aws kms encrypt`. The service decrypts the blob at start-up using
+  the region provided by `PII_KMS_REGION` (or `AWS_REGION`).
+
+## Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `PII_ENCRYPTION_KEYS` | JSON array of `{ "kid": string, "material"?: string, "ciphertext"?: string }`. Each entry must provide either `material` or `ciphertext`. AES-256 keys must decode to 32 bytes. |
+| `PII_ENCRYPTION_ACTIVE_KID` | Identifier of the key the API gateway should use when encrypting new payloads. |
+| `PII_TOKEN_SALTS` | JSON array of `{ "sid": string, "secret"?: string, "ciphertext"?: string }`. Salts must decode to at least 16 bytes. |
+| `PII_TOKEN_ACTIVE_SID` | Identifier of the active salt used for TFN tokenisation. |
+| `PII_KMS_REGION` | Optional. Region used when decrypting ciphertext entries with AWS KMS. If omitted we fall back to `AWS_REGION`. |
+
+All variables must be present for the service to decrypt TFNs. Missing or
+malformed configuration causes the `/admin/pii/decrypt` route to return
+`pii_unconfigured` until a valid configuration is provided.
+
+## Rotation procedure
+
+1. **Generate new material**
+   - To rotate with KMS, run `aws kms encrypt --key-id <KEY_ARN> --plaintext fileb://key.bin --query CiphertextBlob --output text` to produce a ciphertext blob for the new 32 byte key or salt.
+   - For direct secrets store, create a 32 byte random value using `openssl rand -base64 32` for AES keys and at least 16 bytes for salts.
+2. **Update `PII_ENCRYPTION_KEYS` / `PII_TOKEN_SALTS`**
+   - Append the new entry with its `kid`/`sid` and ciphertext (or base64 material).
+   - Keep at least one previous entry available so old payloads remain decryptable.
+3. **Activate the new version**
+   - Set `PII_ENCRYPTION_ACTIVE_KID` or `PII_TOKEN_ACTIVE_SID` to the identifier of the new entry.
+   - Deploy the configuration. The API gateway logs the active identifiers once configured.
+4. **Verify**
+   - Call the `/admin/pii/decrypt` endpoint using an admin token to ensure encryption/decryption still succeeds.
+   - Confirm audit logs show the new key identifier.
+5. **Retire old material**
+   - After any historical payloads encrypted with the previous key/salt are no longer needed, remove the retired entry from the JSON arrays and redeploy.
+
+Keep ciphertext blobs and raw key material out of version control. Store them in
+secrets management (e.g. AWS Secrets Manager or SSM Parameter Store) and inject
+as environment variables at deploy time.

--- a/shared/package.json
+++ b/shared/package.json
@@ -10,7 +10,8 @@
                     "build":  "echo building shared"
                 },
     "dependencies":  {
-                         "@prisma/client":  "6.17.1"
+                         "@prisma/client":  "6.17.1",
+                         "@aws-sdk/client-kms": "^3.684.0"
                      },
     "devDependencies":  {
                             "prisma":  "6.17.1",
@@ -19,6 +20,7 @@
     "exports":  {
                     ".":  "./src/index.ts",
                     "./db":  "./src/db.ts",
-                    "./masking":  "./src/masking.ts"
+                    "./masking":  "./src/masking.ts",
+                    "./pii": "./src/pii/index.ts"
                 }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿export * from "./masking";
+export * from "./masking";
+export * from "./pii";

--- a/shared/src/pii/environment.ts
+++ b/shared/src/pii/environment.ts
@@ -1,0 +1,213 @@
+import {
+  type EncryptionKey,
+  type KeyManagementService,
+  type SaltMaterial,
+  type TokenSaltProvider,
+} from "./types";
+
+const KEY_ENV = "PII_ENCRYPTION_KEYS";
+const ACTIVE_KEY_ENV = "PII_ENCRYPTION_ACTIVE_KID";
+const SALT_ENV = "PII_TOKEN_SALTS";
+const ACTIVE_SALT_ENV = "PII_TOKEN_ACTIVE_SID";
+const KMS_REGION_ENV = "PII_KMS_REGION";
+
+type RawKeyRecord = {
+  kid: string;
+  material?: string;
+  ciphertext?: string;
+};
+
+type RawSaltRecord = {
+  sid: string;
+  secret?: string;
+  ciphertext?: string;
+};
+
+type KmsClientConstructor = typeof import("@aws-sdk/client-kms").KMSClient;
+type DecryptCommandConstructor = typeof import("@aws-sdk/client-kms").DecryptCommand;
+
+type KmsModuleShape = {
+  KMSClient: KmsClientConstructor;
+  DecryptCommand: DecryptCommandConstructor;
+};
+
+let kmsModule: KmsModuleShape | undefined;
+let kmsClient: InstanceType<KmsClientConstructor> | undefined;
+
+function parseJsonEnv<T>(envName: string): T {
+  const raw = process.env[envName];
+  if (!raw) {
+    throw new Error(`${envName} is not configured`);
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    throw new Error(`${envName} is not valid JSON: ${(error as Error).message}`);
+  }
+}
+
+function decodeBase64(value: string, label: string): Buffer {
+  try {
+    const decoded = Buffer.from(value, "base64");
+    if (decoded.length === 0) {
+      throw new Error(`${label} decoded to an empty buffer`);
+    }
+    return decoded;
+  } catch (error) {
+    throw new Error(`${label} is not valid base64: ${(error as Error).message}`);
+  }
+}
+
+async function loadKmsModule(): Promise<KmsModuleShape> {
+  if (!kmsModule) {
+    try {
+      const mod = await import("@aws-sdk/client-kms");
+      kmsModule = { KMSClient: mod.KMSClient, DecryptCommand: mod.DecryptCommand };
+    } catch (error) {
+      throw new Error(
+        "@aws-sdk/client-kms is not available. Install the dependency to use ciphertext entries.",
+      );
+    }
+  }
+  return kmsModule;
+}
+
+async function decryptWithKMS(ciphertext: string): Promise<Buffer> {
+  const module = await loadKmsModule();
+  if (!kmsClient) {
+    const region = process.env[KMS_REGION_ENV] ?? process.env.AWS_REGION;
+    if (!region) {
+      throw new Error("PII_KMS_REGION or AWS_REGION must be set to use ciphertext entries");
+    }
+    kmsClient = new module.KMSClient({ region });
+  }
+
+  const command = new module.DecryptCommand({ CiphertextBlob: Buffer.from(ciphertext, "base64") });
+  const { Plaintext } = await kmsClient.send(command);
+  if (!Plaintext) {
+    throw new Error("KMS decrypt returned an empty payload");
+  }
+  return Buffer.isBuffer(Plaintext) ? Buffer.from(Plaintext) : Buffer.from(Plaintext as Uint8Array);
+}
+
+async function loadKeyMaterial(record: RawKeyRecord): Promise<Buffer> {
+  if (record.material) {
+    return decodeBase64(record.material, `encryption key ${record.kid}`);
+  }
+  if (record.ciphertext) {
+    return decryptWithKMS(record.ciphertext);
+  }
+  throw new Error(`encryption key ${record.kid} must define material or ciphertext`);
+}
+
+async function loadSaltMaterial(record: RawSaltRecord): Promise<Buffer> {
+  if (record.secret) {
+    return decodeBase64(record.secret, `salt ${record.sid}`);
+  }
+  if (record.ciphertext) {
+    return decryptWithKMS(record.ciphertext);
+  }
+  throw new Error(`salt ${record.sid} must define secret or ciphertext`);
+}
+
+function cloneKey(key: EncryptionKey): EncryptionKey {
+  return { kid: key.kid, material: Buffer.from(key.material) };
+}
+
+function cloneSalt(salt: SaltMaterial): SaltMaterial {
+  return { sid: salt.sid, secret: Buffer.from(salt.secret) };
+}
+
+export interface EnvironmentPIIProviders {
+  kms: KeyManagementService;
+  saltProvider: TokenSaltProvider;
+}
+
+export async function loadEnvironmentPIIProviders(): Promise<EnvironmentPIIProviders> {
+  const rawKeys = parseJsonEnv<RawKeyRecord[]>(KEY_ENV);
+  const activeKid = process.env[ACTIVE_KEY_ENV];
+  if (!activeKid) {
+    throw new Error(`${ACTIVE_KEY_ENV} is not configured`);
+  }
+  if (!Array.isArray(rawKeys) || rawKeys.length === 0) {
+    throw new Error(`${KEY_ENV} must be a non-empty JSON array`);
+  }
+
+  const keyEntries = await Promise.all(
+    rawKeys.map(async (record) => ({ kid: record.kid, material: await loadKeyMaterial(record) })),
+  );
+
+  const keyMap = new Map<string, EncryptionKey>();
+  for (const entry of keyEntries) {
+    if (!entry.kid) {
+      throw new Error("encryption key entries must include a kid");
+    }
+    if (entry.material.length !== 32) {
+      throw new Error(`encryption key ${entry.kid} must be 32 bytes for AES-256`);
+    }
+    keyMap.set(entry.kid, entry);
+  }
+
+  if (!keyMap.has(activeKid)) {
+    throw new Error(`active encryption kid ${activeKid} is not present in ${KEY_ENV}`);
+  }
+
+  const kms: KeyManagementService = {
+    getActiveKey: () => {
+      const key = keyMap.get(activeKid);
+      if (!key) {
+        throw new Error("Active encryption key is unavailable");
+      }
+      return cloneKey(key);
+    },
+    getKeyById: (kid: string) => {
+      const key = keyMap.get(kid);
+      return key ? cloneKey(key) : undefined;
+    },
+  };
+
+  const rawSalts = parseJsonEnv<RawSaltRecord[]>(SALT_ENV);
+  const activeSid = process.env[ACTIVE_SALT_ENV];
+  if (!activeSid) {
+    throw new Error(`${ACTIVE_SALT_ENV} is not configured`);
+  }
+  if (!Array.isArray(rawSalts) || rawSalts.length === 0) {
+    throw new Error(`${SALT_ENV} must be a non-empty JSON array`);
+  }
+
+  const saltEntries = await Promise.all(
+    rawSalts.map(async (record) => ({ sid: record.sid, secret: await loadSaltMaterial(record) })),
+  );
+
+  const saltMap = new Map<string, SaltMaterial>();
+  for (const entry of saltEntries) {
+    if (!entry.sid) {
+      throw new Error("salt entries must include a sid");
+    }
+    if (entry.secret.length < 16) {
+      throw new Error(`salt ${entry.sid} must be at least 16 bytes`);
+    }
+    saltMap.set(entry.sid, entry);
+  }
+
+  if (!saltMap.has(activeSid)) {
+    throw new Error(`active salt sid ${activeSid} is not present in ${SALT_ENV}`);
+  }
+
+  const saltProvider: TokenSaltProvider = {
+    getActiveSalt: () => {
+      const salt = saltMap.get(activeSid);
+      if (!salt) {
+        throw new Error("Active token salt is unavailable");
+      }
+      return cloneSalt(salt);
+    },
+    getSaltById: (sid: string) => {
+      const salt = saltMap.get(sid);
+      return salt ? cloneSalt(salt) : undefined;
+    },
+  };
+
+  return { kms, saltProvider };
+}

--- a/shared/src/pii/index.ts
+++ b/shared/src/pii/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./environment";

--- a/shared/src/pii/types.ts
+++ b/shared/src/pii/types.ts
@@ -1,0 +1,30 @@
+export interface EncryptionKey {
+  kid: string;
+  material: Buffer;
+}
+
+export interface KeyManagementService {
+  getActiveKey(): EncryptionKey;
+  getKeyById(kid: string): EncryptionKey | undefined;
+}
+
+export interface SaltMaterial {
+  sid: string;
+  secret: Buffer;
+}
+
+export interface TokenSaltProvider {
+  getActiveSalt(): SaltMaterial;
+  getSaltById(id: string): SaltMaterial | undefined;
+}
+
+export interface AuditEvent {
+  actorId: string;
+  action: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditLogger {
+  record(event: AuditEvent): void | Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add shared PII provider utilities that source encryption keys and salts from environment or AWS KMS ciphertext
- configure the API gateway to load the shared providers, register the decrypt route, and enforce the admin guard
- expand PII route tests and add key rotation guidance to the security docs

## Testing
- pnpm --filter @apgms/api-gateway exec tsx --test test/pii.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f79c735b7483278aa00fd8395c06be