### PR TITLE
Document security controls and status operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# APGMS
+# APGMS
 
 Quickstart:
 pnpm i
@@ -12,3 +12,11 @@ pnpm -w exec playwright test
 - Store any developer-provisioned KMS credentials in `artifacts/kms/`. The directory is
   tracked in git via a `.gitkeep`, while the JSON key material is ignored so local keys
   never end up in version control.
+
+## Security and Operations Documentation
+
+- [ASVS control mapping](docs/security/ASVS.md)
+- [TFN handling SOP](docs/security/TFN-SOP.md)
+- [Status site operations guide](status/README.md)
+- [Status page runbook](runbooks/status-page.md)
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,9 @@
-﻿# Security Policy
+# Security Policy
 Email: security@yourdomain.example
+
+## Additional Resources
+
+- [ASVS control mapping](docs/security/ASVS.md)
+- [TFN handling SOP](docs/security/TFN-SOP.md)
+- [Status page runbook](runbooks/status-page.md)
+

--- a/docs/security/ASVS.md
+++ b/docs/security/ASVS.md
@@ -1,0 +1,13 @@
+# OWASP ASVS L2 Control Mapping
+
+This appendix documents how key OWASP ASVS Level 2 controls are implemented and tested within the APGMS platform.
+
+| Control | Requirement | Implementation | Evidence |
+| --- | --- | --- | --- |
+| V2.1.1 | Require authentication for administrative APIs. | `services/api-gateway/src/routes/admin.data.ts` validates bearer principals before exporting data. | `services/api-gateway/test/admin.data.export.spec.ts` verifies unauthenticated calls receive `401 Unauthorized`. |
+| V2.1.2 | Enforce role-based access for high-privilege actions. | The admin export handler checks the principal role and organisation match before fulfilling the request. | Tests assert that non-admin principals receive `403 Forbidden`. |
+| V2.5.2 | Gate sensitive operations behind explicit administrative approval. | `services/api-gateway/src/lib/pii.ts` injects a guard for `/admin/pii/decrypt` before decrypting secrets. | `services/api-gateway/test/pii.spec.ts` exercises both allowed and denied guard paths. |
+| V9.1.1 | Protect sensitive data at rest using strong encryption. | `encryptPII` in `services/api-gateway/src/lib/pii.ts` uses AES-256-GCM with per-message IVs and auth tags. | PII unit tests encrypt and decrypt payloads, ensuring ciphertext safety. |
+| V9.4.1 | Ensure tax identifiers are irreversibly tokenised. | `tokenizeTFN` normalises TFNs and returns salted HMAC digests. | Tests confirm exported tokens never contain the original TFN digits. |
+| V10.3.1 | Generate security audit trails for administrative access. | Admin export routes emit structured entries to access and security logs. | Tests assert that log sinks record `data_export` events with subject metadata. |
+

--- a/docs/security/TFN-SOP.md
+++ b/docs/security/TFN-SOP.md
@@ -1,1 +1,20 @@
-﻿# TFN handling SOP
+# TFN Handling SOP
+
+This standard operating procedure ensures Australian Tax File Numbers (TFNs) are collected, processed, stored, and deleted in compliance with privacy obligations.
+
+## 1. Collection and Handling
+- Collect TFNs only when required for authorised use-cases (e.g. payroll onboarding).
+- Transmit TFNs over TLS-protected channels and immediately tokenise them in application services using the shared PII library.
+- Application handlers must call `tokenizeTFN` so the raw TFN is never persisted or logged; the helper enforces format validation prior to hashing.【F:services/api-gateway/src/lib/pii.ts†L42-L58】
+- Automated tests assert that TFN tokens do not reveal the original digits, providing regression coverage for this requirement.【F:services/api-gateway/test/pii.spec.ts†L45-L63】
+
+## 2. Storage and Access Controls
+- Store only the salted token returned by `tokenizeTFN`. Persisting raw TFNs or unsalted hashes is prohibited.
+- When TFNs must be re-identified (e.g. responding to a regulator), restrict access to the `/admin/pii/decrypt` endpoint to authorised administrators via the guard callback defined in `registerPIIRoutes`.
+- The decrypt route requires a positive guard decision and records an audit trail with the acting administrator and key ID, ensuring privileged access is monitored.【F:services/api-gateway/src/lib/pii.ts†L84-L133】【F:services/api-gateway/test/pii.spec.ts†L65-L105】
+
+## 3. Retention and Deletion
+- Honour deletion requests by removing the stored TFN tokens and any dependent references from downstream systems. Because the original TFN cannot be reconstructed from the token, deleting the token renders the TFN irrecoverable.
+- Where deletion is part of a broader subject access request, follow the administrative export/delete flows to confirm the subject before purging associated records; these flows emit security and access logs for traceability.【F:services/api-gateway/test/admin.data.export.spec.ts†L1-L123】
+- Confirm completion by updating the incident or request ticket with the database record references removed and timestamp of deletion.
+

--- a/runbooks/ndb.md
+++ b/runbooks/ndb.md
@@ -61,7 +61,8 @@ Heads-up: we have declared an NDB incident (INC-<number>). All external communic
 ## 5. Execute notifications
 - Send regulator notification within 72 hours of confirmation.
 - Email impacted customers after legal review and before public disclosure.
-- Update the status page template with an incident summary and remediation steps.
+- Coordinate with the status page controller to publish and maintain customer updates according to the [status page runbook](./status-page.md).
+- Ensure customer communications reflect the same timestamps and mitigation progress posted to the status page.
 
 ## 6. Post-incident activities
 - Run the full retrospective within 7 days.

--- a/runbooks/status-page.md
+++ b/runbooks/status-page.md
@@ -1,0 +1,40 @@
+# Status Page Runbook
+
+Use this runbook when the public status page requires manual intervention during an incident or scheduled maintenance.
+
+## 1. Preparation
+- Confirm you have OpsGenie and CDN access before starting your on-call shift.
+- Join the active incident channel (e.g. `#inc-<date>-<service>`) to mirror updates posted to the status page.
+- Bookmark the tooling links listed in [status/README.md](../status/README.md).
+
+## 2. Declaring an Incident
+1. Open the OpsGenie incident and click **Update Statuspage**.
+2. Select affected components and set the severity:
+   - **Minor:** Partial degradation with workarounds.
+   - **Major:** Customer-facing downtime or severe latency.
+   - **Critical:** Complete outage of a core journey.
+3. Publish the first customer update within 15 minutes including:
+   - Impact summary.
+   - Time of detection.
+   - Owner handling mitigation.
+4. Post a matching update in the incident Slack channel to keep internal stakeholders aligned.
+
+## 3. Ongoing Communications
+- Add timeline updates at least every 30 minutes; include hypothesis, mitigation progress, and next checkpoint.
+- If no mitigation progress for 45 minutes, escalate to the secondary on-call rotation and request subject-matter experts.
+- Attach graphs or screenshots when they help customers understand the impact.
+
+## 4. Resolution
+- When mitigated, update component status to **Operational** and post a resolution summary.
+- Trigger the "Send subscriber email" option to notify subscribers of recovery.
+- Capture action items for the retrospective and link the document once published (within 7 days for SEV-1/2).
+
+## 5. Maintenance Events
+- Schedule maintenance at least 48 hours in advance where possible.
+- Include customer impact, maintenance window, and rollback owner in the announcement.
+- Post reminders 1 hour before the window starts and confirm completion when systems are back to normal.
+
+## 6. Auditing and Handover
+- Export the incident timeline after closure and store it in the incident drive for compliance.
+- During shift handover, review open incidents and scheduled maintenance with the incoming on-call engineer.
+

--- a/status/README.md
+++ b/status/README.md
@@ -1,1 +1,43 @@
-﻿# Status site
+# Status Site Operations
+
+The status site communicates production availability, scheduled maintenance, and incident timelines. This guide covers day-to-day upkeep and emergency workflows.
+
+## Platform Overview
+- **Source:** `status/` contains the Next.js project that renders the public page and consumes uptime webhooks.
+- **Hosting:** Deployed via the `status` service pipeline; builds publish static assets to the CDN edge.
+- **Data Sources:**
+  - Synthetic checks from `worker/uptime` drive the "API" and "Console" components.
+  - Manual incidents are created via the on-call form in OpsGenie, which pushes updates to the status API.
+
+## Daily Health Checklist
+- Review overnight incidents before 09:00 local time and confirm they are in the correct resolved state.
+- Validate the subscription webhook by checking the `status-log` dashboard for fresh pings (within the last 15 minutes).
+- Ensure scheduled maintenance events have clear start/end times and associated owners.
+
+## Incident Workflow
+1. **Triage:** Follow the relevant service runbook to determine impact and owner.
+2. **Declare:** Create or update the active incident on the status page with:
+   - Impacted components and customer-facing symptoms.
+   - Timestamped updates every 30 minutes until mitigation.
+   - Links to Slack incident channels for internal coordination.
+3. **Mitigate:** Track mitigation steps and ETA in the incident timeline. Escalate if no mitigation progress is achieved within the SLA below.
+4. **Recover:** When service is stable, post a resolution summary that includes root cause, mitigations, and any follow-up actions.
+5. **Postmortem:** Link the retrospective document once completed so subscribers receive the final summary.
+
+## Escalation Paths
+- **Primary On-Call:** OpsGenie rotation `platform-oncall`.
+- **Secondary:** Page the `infrastructure` rotation if the primary does not acknowledge within 15 minutes.
+- **Executive Visibility:** Notify the COO and Head of Support for incidents breaching customer SLAs.
+- **Regulatory:** If customer data exposure is suspected, immediately follow the [NDB runbook](../runbooks/ndb.md) in parallel.
+
+## Communication SLAs
+- **Initial customer update:** within 15 minutes of declaring the incident.
+- **Subsequent updates:** at least every 30 minutes while the incident is ongoing.
+- **Customer notification of resolution:** within 10 minutes of mitigation.
+- **Retrospective publication:** within 7 calendar days for SEV-1 and SEV-2 incidents.
+
+## Tooling Quick Links
+- OpsGenie incident dashboard: <https://opsgenie.example.com/incidents>
+- Grafana synthetic check dashboard: <https://grafana.example.com/d/status>
+- Status site repo (`status/`): <https://git.example.com/apgms/status>
+


### PR DESCRIPTION
## Summary
- add an OWASP ASVS Level 2 mapping that references existing security tests
- expand the TFN handling SOP and link the new guidance from the root docs
- document status page operating procedures, including a dedicated runbook and NDB cross-references

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f79c724a908327befff29c765c7c74