### PR TITLE
feat: enforce admin jwt authentication

### DIFF
--- a/services/api-gateway/src/auth/jwt.ts
+++ b/services/api-gateway/src/auth/jwt.ts
@@ -1,0 +1,173 @@
+import { createHmac, createVerify, type KeyObject } from "node:crypto";
+
+import { getAdminAuthConfig } from "../config";
+
+export type AdminTokenClaims = {
+  [key: string]: unknown;
+  sub: string;
+  orgId: string;
+  role: string;
+  email?: string;
+  iss: string;
+  aud: string | string[];
+  exp: number;
+};
+
+export class AdminTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AdminTokenError";
+  }
+}
+
+function base64UrlDecode(segment: string): Buffer {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  const padded =
+    padding === 2
+      ? `${normalized}==`
+      : padding === 3
+        ? `${normalized}=`
+        : normalized;
+  if (padding === 1) {
+    throw new AdminTokenError("invalid token encoding");
+  }
+  return Buffer.from(padded, "base64");
+}
+
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+function verifySignature(
+  algorithm: "HS256" | "RS256",
+  signingInput: string,
+  signature: string,
+  key: Uint8Array | KeyObject
+): void {
+  if (algorithm === "HS256") {
+    if (!(key instanceof Uint8Array) && !(key instanceof Buffer)) {
+      throw new AdminTokenError("invalid symmetric key");
+    }
+    const expected = createHmac("sha256", key).update(signingInput).digest("base64url");
+    if (!constantTimeCompare(expected, signature)) {
+      throw new AdminTokenError("invalid token signature");
+    }
+    return;
+  }
+
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(signingInput);
+  verifier.end();
+  const sigBuffer = base64UrlDecode(signature);
+  if (!verifier.verify(key, sigBuffer)) {
+    throw new AdminTokenError("invalid token signature");
+  }
+}
+
+function assertAudience(audClaim: unknown, expected: string): asserts audClaim is string | string[] {
+  if (typeof audClaim === "string") {
+    if (audClaim !== expected) {
+      throw new AdminTokenError("invalid audience");
+    }
+    return;
+  }
+  if (Array.isArray(audClaim)) {
+    if (!audClaim.includes(expected)) {
+      throw new AdminTokenError("invalid audience");
+    }
+    return;
+  }
+  throw new AdminTokenError("invalid audience");
+}
+
+export async function verifyAdminToken(token: string): Promise<AdminTokenClaims> {
+  if (!token) {
+    throw new AdminTokenError("token missing");
+  }
+
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new AdminTokenError("invalid token format");
+  }
+
+  let headerJson: string;
+  let payloadJson: string;
+  try {
+    headerJson = base64UrlDecode(parts[0]).toString("utf8");
+    payloadJson = base64UrlDecode(parts[1]).toString("utf8");
+  } catch (error) {
+    throw new AdminTokenError("invalid token encoding");
+  }
+
+  let header: { alg?: string; typ?: string };
+  let payload: Record<string, unknown>;
+  try {
+    header = JSON.parse(headerJson);
+    payload = JSON.parse(payloadJson);
+  } catch (error) {
+    throw new AdminTokenError("invalid token structure");
+  }
+
+  const config = getAdminAuthConfig();
+  if (!header.alg || header.alg !== config.algorithm) {
+    throw new AdminTokenError("unexpected algorithm");
+  }
+
+  verifySignature(config.algorithm, `${parts[0]}.${parts[1]}`, parts[2], config.key);
+
+  const issuer = payload.iss;
+  if (typeof issuer !== "string" || issuer !== config.issuer) {
+    throw new AdminTokenError("invalid issuer");
+  }
+
+  const audienceClaim = payload.aud;
+  assertAudience(audienceClaim, config.audience);
+
+  const exp = payload.exp;
+  if (typeof exp !== "number") {
+    throw new AdminTokenError("missing expiry");
+  }
+  const now = Math.floor(Date.now() / 1000);
+  if (exp <= now) {
+    throw new AdminTokenError("token expired");
+  }
+
+  const notBefore = payload.nbf;
+  if (typeof notBefore === "number" && notBefore > now) {
+    throw new AdminTokenError("token not active");
+  }
+
+  const subject = payload.sub;
+  if (typeof subject !== "string" || subject.length === 0) {
+    throw new AdminTokenError("missing subject");
+  }
+
+  const roleClaim = payload.role;
+  if (typeof roleClaim !== "string") {
+    throw new AdminTokenError("missing role claim");
+  }
+
+  const orgId = payload.orgId;
+  if (typeof orgId !== "string" || orgId.length === 0) {
+    throw new AdminTokenError("missing orgId claim");
+  }
+
+  const email = typeof payload.email === "string" ? payload.email : undefined;
+
+  return {
+    ...payload,
+    sub: subject,
+    orgId,
+    role: roleClaim,
+    email,
+    iss: issuer,
+    aud: audienceClaim,
+    exp,
+  } as AdminTokenClaims;
+}

--- a/services/api-gateway/src/auth/require-admin.ts
+++ b/services/api-gateway/src/auth/require-admin.ts
@@ -1,0 +1,62 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import { maskError } from "@apgms/shared";
+
+import { AdminTokenError, verifyAdminToken, type AdminTokenClaims } from "./jwt";
+
+export interface AdminPrincipal {
+  id: string;
+  orgId: string;
+  email?: string;
+  token: string;
+  claims: AdminTokenClaims;
+}
+
+function extractBearerToken(req: FastifyRequest): string | null {
+  const header = req.headers["authorization"] ?? req.headers["Authorization" as keyof typeof req.headers];
+  if (!header) {
+    return null;
+  }
+
+  const value = Array.isArray(header) ? header[0] : header;
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
+  return match ? match[1] : null;
+}
+
+export async function requireAdmin(
+  req: FastifyRequest,
+  rep: FastifyReply
+): Promise<AdminPrincipal | null> {
+  const token = extractBearerToken(req);
+  if (!token) {
+    req.log.warn("admin token missing");
+    void rep.code(401).send({ error: "unauthorized" });
+    return null;
+  }
+
+  try {
+    const claims = await verifyAdminToken(token);
+    if (claims.role !== "admin") {
+      req.log.warn({ role: claims.role }, "principal not authorised for admin access");
+      void rep.code(403).send({ error: "forbidden" });
+      return null;
+    }
+
+    return {
+      id: claims.sub,
+      orgId: claims.orgId,
+      email: claims.email,
+      token,
+      claims,
+    };
+  } catch (err) {
+    const isKnown = err instanceof AdminTokenError;
+    req.log.warn({ err: maskError(err) }, "admin token verification failed");
+    void rep.code(isKnown ? 401 : 500).send({ error: "unauthorized" });
+    return null;
+  }
+}

--- a/services/api-gateway/src/config.ts
+++ b/services/api-gateway/src/config.ts
@@ -1,0 +1,103 @@
+import { createPublicKey, type KeyObject } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
+const AdminAuthEnvSchema = z
+  .object({
+    ADMIN_JWT_AUDIENCE: z.string().min(1, "ADMIN_JWT_AUDIENCE is required"),
+    ADMIN_JWT_ISSUER: z.string().min(1, "ADMIN_JWT_ISSUER is required"),
+    ADMIN_JWT_ALGORITHM: z
+      .enum(["RS256", "HS256"], {
+        errorMap: () => ({ message: "ADMIN_JWT_ALGORITHM must be RS256 or HS256" }),
+      })
+      .default("RS256"),
+    ADMIN_JWT_PUBLIC_KEY_FILE: z.string().optional(),
+    ADMIN_JWT_SECRET_FILE: z.string().optional(),
+    ADMIN_JWT_SECRET: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    const { ADMIN_JWT_ALGORITHM: algorithm } = value;
+    if (algorithm === "RS256") {
+      if (!value.ADMIN_JWT_PUBLIC_KEY_FILE) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "ADMIN_JWT_PUBLIC_KEY_FILE is required when ADMIN_JWT_ALGORITHM=RS256",
+          path: ["ADMIN_JWT_PUBLIC_KEY_FILE"],
+        });
+      }
+      if (value.ADMIN_JWT_SECRET || value.ADMIN_JWT_SECRET_FILE) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "ADMIN_JWT_SECRET(_FILE) should not be provided for RS256",
+          path: ["ADMIN_JWT_SECRET"],
+        });
+      }
+    } else if (algorithm === "HS256") {
+      if (!value.ADMIN_JWT_SECRET && !value.ADMIN_JWT_SECRET_FILE) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "ADMIN_JWT_SECRET or ADMIN_JWT_SECRET_FILE is required when ADMIN_JWT_ALGORITHM=HS256",
+          path: ["ADMIN_JWT_SECRET"],
+        });
+      }
+      if (value.ADMIN_JWT_PUBLIC_KEY_FILE) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "ADMIN_JWT_PUBLIC_KEY_FILE should not be provided for HS256",
+          path: ["ADMIN_JWT_PUBLIC_KEY_FILE"],
+        });
+      }
+    }
+  });
+
+export type AdminAuthConfig = {
+  audience: string;
+  issuer: string;
+  algorithm: "RS256" | "HS256";
+  key: KeyObject | Uint8Array;
+};
+
+let cachedAdminAuthConfig: AdminAuthConfig | null = null;
+
+function loadCredentialFromFile(filename: string): string {
+  const resolved = path.isAbsolute(filename)
+    ? filename
+    : path.join(process.cwd(), filename);
+  return readFileSync(resolved, "utf8");
+}
+
+function getKeyMaterial(env: z.infer<typeof AdminAuthEnvSchema>): KeyObject | Uint8Array {
+  if (env.ADMIN_JWT_ALGORITHM === "RS256") {
+    const fileContents = loadCredentialFromFile(env.ADMIN_JWT_PUBLIC_KEY_FILE!);
+    return createPublicKey(fileContents);
+  }
+
+  if (env.ADMIN_JWT_SECRET_FILE) {
+    const secret = loadCredentialFromFile(env.ADMIN_JWT_SECRET_FILE);
+    return new TextEncoder().encode(secret.trim());
+  }
+
+  return new TextEncoder().encode(env.ADMIN_JWT_SECRET!);
+}
+
+export function getAdminAuthConfig(): AdminAuthConfig {
+  if (cachedAdminAuthConfig) {
+    return cachedAdminAuthConfig;
+  }
+
+  const parsed = AdminAuthEnvSchema.parse(process.env);
+  cachedAdminAuthConfig = {
+    audience: parsed.ADMIN_JWT_AUDIENCE,
+    issuer: parsed.ADMIN_JWT_ISSUER,
+    algorithm: parsed.ADMIN_JWT_ALGORITHM,
+    key: getKeyMaterial(parsed),
+  };
+
+  return cachedAdminAuthConfig;
+}
+
+export function __resetAdminAuthConfigForTests(): void {
+  cachedAdminAuthConfig = null;
+}

--- a/services/api-gateway/src/routes/admin.data.ts
+++ b/services/api-gateway/src/routes/admin.data.ts
@@ -1,19 +1,15 @@
-﻿<<<<<<< HEAD
 import { createHash } from "node:crypto";
-import type { FastifyInstance, FastifyRequest } from "fastify";
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+
 import {
   adminDataDeleteRequestSchema,
   adminDataDeleteResponseSchema,
   type AdminDataDeleteRequest,
   type AdminDataDeleteResponse,
+  subjectDataExportRequestSchema,
+  subjectDataExportResponseSchema,
 } from "../schemas/admin.data";
-
-interface Principal {
-  id: string;
-  role: string;
-  orgId: string;
-  token: string;
-}
+import { requireAdmin } from "../auth/require-admin";
 
 export interface SecurityLogPayload {
   event: "data_delete";
@@ -28,10 +24,10 @@ const PASSWORD_PLACEHOLDER = "__deleted__";
 type SharedDbModule = typeof import("../../../../shared/src/db.js");
 type PrismaClientLike = Pick<SharedDbModule["prisma"], "user" | "bankLine">;
 
-interface AdminDataRouteDeps {
+type AdminDataRouteDeps = {
   prisma?: PrismaClientLike;
   secLog?: (payload: SecurityLogPayload) => Promise<void> | void;
-}
+};
 
 export async function registerAdminDataRoutes(
   app: FastifyInstance,
@@ -45,111 +41,11 @@ export async function registerAdminDataRoutes(
     });
 
   app.post("/admin/data/delete", async (request, reply) => {
-    const principal = parseAuthorization(request);
-=======
-import { FastifyPluginAsync, FastifyRequest } from "fastify";
-import { z } from "zod";
-import {
-  subjectDataExportRequestSchema,
-  subjectDataExportResponseSchema,
-} from "../schemas/admin.data";
-
-const principalSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  role: z.enum(["admin", "user"]),
-  email: z.string().email(),
-});
-
-type Principal = z.infer<typeof principalSchema>;
-
-type DbClient = {
-  user: {
-    findFirst: (args: {
-      where: { email: string; orgId: string };
-      select: {
-        id: true;
-        email: true;
-        createdAt: true;
-        org: { select: { id: true; name: true } };
-      };
-    }) => Promise<
-      | {
-          id: string;
-          email: string;
-          createdAt: Date;
-          org: { id: string; name: string };
-        }
-      | null
-    >;
-  };
-  bankLine: {
-    count: (args: { where: { orgId: string } }) => Promise<number>;
-  };
-  accessLog?: {
-    create: (args: {
-      data: {
-        event: string;
-        orgId: string;
-        principalId: string;
-        subjectEmail: string;
-      };
-    }) => Promise<unknown>;
-  };
-};
-
-type SecLogFn = (payload: {
-  event: string;
-  orgId: string;
-  principal: string;
-  subjectEmail: string;
-}) => void;
-
-const parsePrincipal = (req: FastifyRequest): Principal | null => {
-  const header = req.headers.authorization;
-  if (!header) return null;
-  const match = /^Bearer\s+(.+)$/i.exec(header);
-  if (!match) return null;
-  try {
-    const decoded = Buffer.from(match[1], "base64url").toString("utf8");
-    const parsed = JSON.parse(decoded);
-    return principalSchema.parse(parsed);
-  } catch {
-    return null;
-  }
-};
-
-const adminDataRoutes: FastifyPluginAsync = async (app) => {
-  const db: DbClient | undefined = (app as any).db;
-  if (!db) {
-    throw new Error("database client not registered");
-  }
-
-  const log: SecLogFn =
-    (app as any).secLog ??
-    ((entry) => {
-      app.log.info({ event: entry.event, ...entry }, "security_event");
-    });
-
-  app.post("/admin/data/export", async (req, reply) => {
-    const bodyResult = subjectDataExportRequestSchema.safeParse(req.body);
-    if (!bodyResult.success) {
-      return reply.code(400).send({ error: "invalid_request" });
+    const admin = await requireAdmin(request, reply);
+    if (!admin) {
+      return;
     }
 
-    const body = bodyResult.data;
-
-    const principal = parsePrincipal(req);
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-    if (!principal) {
-      return reply.code(401).send({ error: "unauthorized" });
-    }
-
-    if (principal.role !== "admin") {
-      return reply.code(403).send({ error: "forbidden" });
-    }
-
-<<<<<<< HEAD
     const parsed = adminDataDeleteRequestSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: "invalid_request" });
@@ -157,13 +53,10 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
 
     const body = parsed.data;
 
-=======
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-    if (principal.orgId !== body.orgId) {
+    if (admin.orgId !== body.orgId) {
       return reply.code(403).send({ error: "forbidden" });
     }
 
-<<<<<<< HEAD
     const subject = await prisma.user.findFirst({
       where: { orgId: body.orgId, email: body.email },
     });
@@ -209,7 +102,7 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
     await securityLogger({
       event: "data_delete",
       orgId: body.orgId,
-      principal: principal.id,
+      principal: admin.id,
       subjectUserId: subject.id,
       mode: response.action,
     });
@@ -218,30 +111,138 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
   });
 }
 
-function parseAuthorization(request: FastifyRequest): Principal | null {
-  const header = request.headers["authorization"] ?? request.headers["Authorization" as keyof typeof request.headers];
-  if (!header || typeof header !== "string") {
-    return null;
-  }
-
-  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
-  if (!match) {
-    return null;
-  }
-
-  const token = match[1];
-  const [role, principalId, orgId] = token.split(":");
-  if (!role || !principalId || !orgId) {
-    return null;
-  }
-
-  return {
-    id: principalId,
-    role,
-    orgId,
-    token,
+type DbClient = {
+  user: {
+    findFirst: (args: {
+      where: { email: string; orgId: string };
+      select: {
+        id: true;
+        email: true;
+        createdAt: true;
+        org: { select: { id: true; name: true } };
+      };
+    }) => Promise<
+      | {
+          id: string;
+          email: string;
+          createdAt: Date;
+          org: { id: string; name: string };
+        }
+      | null
+    >;
   };
-}
+  bankLine: {
+    count: (args: { where: { orgId: string } }) => Promise<number>;
+  };
+  accessLog?: {
+    create: (args: {
+      data: {
+        event: string;
+        orgId: string;
+        principalId: string;
+        subjectEmail: string;
+      };
+    }) => Promise<unknown>;
+  };
+};
+
+type SecLogFn = (payload: {
+  event: string;
+  orgId: string;
+  principal: string;
+  subjectEmail: string;
+}) => void;
+
+const adminDataRoutes: FastifyPluginAsync = async (app) => {
+  const db: DbClient | undefined = (app as any).db;
+  if (!db) {
+    throw new Error("database client not registered");
+  }
+
+  const log: SecLogFn =
+    (app as any).secLog ??
+    ((entry) => {
+      app.log.info({ event: entry.event, ...entry }, "security_event");
+    });
+
+  app.post("/admin/data/export", async (req, reply) => {
+    const bodyResult = subjectDataExportRequestSchema.safeParse(req.body);
+    if (!bodyResult.success) {
+      return reply.code(400).send({ error: "invalid_request" });
+    }
+
+    const admin = await requireAdmin(req, reply);
+    if (!admin) {
+      return;
+    }
+
+    const body = bodyResult.data;
+
+    if (admin.orgId !== body.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const userRecord = await db.user.findFirst({
+      where: { email: body.email, orgId: body.orgId },
+      select: {
+        id: true,
+        email: true,
+        createdAt: true,
+        org: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!userRecord) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const bankLinesCount = await db.bankLine.count({
+      where: { orgId: body.orgId },
+    });
+
+    const exportedAt = new Date().toISOString();
+
+    if (db.accessLog?.create) {
+      await db.accessLog.create({
+        data: {
+          event: "data_export",
+          orgId: body.orgId,
+          principalId: admin.id,
+          subjectEmail: body.email,
+        },
+      });
+    }
+
+    log({
+      event: "data_export",
+      orgId: body.orgId,
+      principal: admin.id,
+      subjectEmail: body.email,
+    });
+
+    const responsePayload = {
+      org: {
+        id: userRecord.org.id,
+        name: userRecord.org.name,
+      },
+      user: {
+        id: userRecord.id,
+        email: userRecord.email,
+        createdAt: userRecord.createdAt.toISOString(),
+      },
+      relationships: {
+        bankLinesCount,
+      },
+      exportedAt,
+    };
+
+    const validated = subjectDataExportResponseSchema.parse(responsePayload);
+
+    return reply.send(validated);
+  });
+};
+
+export default adminDataRoutes;
 
 async function detectForeignKeyRisk(
   prisma: PrismaClientLike,
@@ -288,67 +289,3 @@ async function getDefaultPrisma(): Promise<PrismaClientLike> {
 }
 
 export type { AdminDataDeleteRequest, AdminDataDeleteResponse };
-=======
-    const userRecord = await db.user.findFirst({
-      where: { email: body.email, orgId: body.orgId },
-      select: {
-        id: true,
-        email: true,
-        createdAt: true,
-        org: { select: { id: true, name: true } },
-      },
-    });
-
-    if (!userRecord) {
-      return reply.code(404).send({ error: "not_found" });
-    }
-
-    const bankLinesCount = await db.bankLine.count({
-      where: { orgId: body.orgId },
-    });
-
-    const exportedAt = new Date().toISOString();
-
-    if (db.accessLog?.create) {
-      await db.accessLog.create({
-        data: {
-          event: "data_export",
-          orgId: body.orgId,
-          principalId: principal.id,
-          subjectEmail: body.email,
-        },
-      });
-    }
-
-    log({
-      event: "data_export",
-      orgId: body.orgId,
-      principal: principal.id,
-      subjectEmail: body.email,
-    });
-
-    const responsePayload = {
-      org: {
-        id: userRecord.org.id,
-        name: userRecord.org.name,
-      },
-      user: {
-        id: userRecord.id,
-        email: userRecord.email,
-        createdAt: userRecord.createdAt.toISOString(),
-      },
-      relationships: {
-        bankLinesCount,
-      },
-      exportedAt,
-    };
-
-    const validated = subjectDataExportResponseSchema.parse(responsePayload);
-
-    return reply.send(validated);
-  });
-};
-
-export default adminDataRoutes;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-

--- a/services/api-gateway/src/schemas/admin.data.ts
+++ b/services/api-gateway/src/schemas/admin.data.ts
@@ -1,6 +1,5 @@
-﻿import { z } from "zod";
+import { z } from "zod";
 
-<<<<<<< HEAD
 export const adminDataDeleteRequestSchema = z.object({
   orgId: z.string().min(1, "orgId is required"),
   email: z.string().email("email must be valid"),
@@ -19,7 +18,7 @@ export const adminDataDeleteResponseSchema = z.object({
 
 export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
 export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
-=======
+
 export const subjectDataExportRequestSchema = z.object({
   orgId: z.string().min(1),
   email: z.string().email(),
@@ -47,12 +46,5 @@ export const subjectDataExportResponseSchema = z.object({
   exportedAt: z.string(),
 });
 
-export type SubjectDataExportRequest = z.infer<
-  typeof subjectDataExportRequestSchema
->;
-
-export type SubjectDataExportResponse = z.infer<
-  typeof subjectDataExportResponseSchema
->;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-
+export type SubjectDataExportRequest = z.infer<typeof subjectDataExportRequestSchema>;
+export type SubjectDataExportResponse = z.infer<typeof subjectDataExportResponseSchema>;


### PR DESCRIPTION
## Summary
- add configuration helpers and JWT validation utilities for admin auth
- require verified admin principals in admin routes and Fastify handlers
- expand admin tests to cover valid and invalid token scenarios

## Testing
- pnpm exec tsx --test test/admin.data.delete.spec.ts
- pnpm exec tsx --test test/admin.data.export.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f79c709aac83278064383644a63a4a