### PR TITLE
feat: harden api gateway cors and csp

### DIFF
--- a/services/api-gateway/src/plugins/security-headers.ts
+++ b/services/api-gateway/src/plugins/security-headers.ts
@@ -1,0 +1,54 @@
+import type { FastifyPluginAsync } from "fastify";
+
+export type CspDirectives = Record<string, readonly string[]>;
+
+export interface SecurityHeadersOptions {
+  contentSecurityPolicy: {
+    directives: CspDirectives;
+  };
+}
+
+function serializeDirectives(directives: CspDirectives): string {
+  return Object.entries(directives)
+    .map(([directive, values]) => {
+      const entries = values.filter((value) => value.length > 0);
+      if (entries.length === 0) {
+        return directive;
+      }
+      return `${directive} ${entries.join(" ")}`;
+    })
+    .join("; ");
+}
+
+const securityHeaders: FastifyPluginAsync<SecurityHeadersOptions> = async (fastify, options) => {
+  const cspHeaderValue = serializeDirectives(options.contentSecurityPolicy.directives);
+  fastify.log.debug({ cspHeaderValue }, "security headers ready");
+
+  fastify.addHook("onRequest", async (_request, reply) => {
+    reply
+      .header("Content-Security-Policy", cspHeaderValue)
+      .header("X-Content-Type-Options", "nosniff")
+      .header("X-Frame-Options", "DENY")
+      .header("Referrer-Policy", "no-referrer")
+      .header("X-DNS-Prefetch-Control", "off")
+      .header("X-Download-Options", "noopen")
+      .header("X-Permitted-Cross-Domain-Policies", "none")
+      .header("Cross-Origin-Opener-Policy", "same-origin")
+      .header("Cross-Origin-Resource-Policy", "same-origin")
+      .header("X-XSS-Protection", "0");
+    const raw = reply.raw;
+    raw.setHeader("Content-Security-Policy", cspHeaderValue);
+    raw.setHeader("content-security-policy", cspHeaderValue);
+    raw.setHeader("X-Content-Type-Options", "nosniff");
+    raw.setHeader("X-Frame-Options", "DENY");
+    raw.setHeader("Referrer-Policy", "no-referrer");
+    raw.setHeader("X-DNS-Prefetch-Control", "off");
+    raw.setHeader("X-Download-Options", "noopen");
+    raw.setHeader("X-Permitted-Cross-Domain-Policies", "none");
+    raw.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+    raw.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    raw.setHeader("X-XSS-Protection", "0");
+  });
+};
+
+export default securityHeaders;

--- a/services/api-gateway/test/security.spec.ts
+++ b/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+
+import type { FastifyInstance } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+
+import { createApp } from "../src/app";
+
+const ALLOWED_ORIGIN = "https://frontend.example.test";
+const EXPECTED_CSP =
+  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; font-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests";
+
+let app: FastifyInstance;
+let originalAllowedOrigins: string | undefined;
+
+beforeEach(async () => {
+  originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+  process.env.ALLOWED_ORIGINS = ALLOWED_ORIGIN;
+
+  app = await createApp({ prisma: createPrismaStub() });
+  await app.ready();
+});
+
+afterEach(async () => {
+  process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+  await app.close();
+});
+
+test("allows configured origins and exposes CORS/CSP headers", async () => {
+  const preflight = await app.inject({
+    method: "OPTIONS",
+    url: "/health",
+    headers: {
+      origin: ALLOWED_ORIGIN,
+      "access-control-request-method": "GET",
+    },
+  });
+
+  assert.equal(preflight.statusCode, 204);
+  assert.equal(preflight.headers["access-control-allow-origin"], ALLOWED_ORIGIN);
+  assert.equal(preflight.headers["access-control-allow-credentials"], "true");
+  assert.match(String(preflight.headers["access-control-allow-methods"]), /GET/);
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { origin: ALLOWED_ORIGIN },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["access-control-allow-origin"], ALLOWED_ORIGIN);
+  assert.equal(response.headers["content-security-policy"], EXPECTED_CSP);
+});
+
+test("rejects disallowed origins", async () => {
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/health",
+    headers: {
+      origin: "https://malicious.example", // not in allow-list
+      "access-control-request-method": "GET",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.equal(response.headers["access-control-allow-origin"], undefined);
+});
+
+function createPrismaStub(): PrismaClient {
+  const stub = {
+    org: {
+      findUnique: async () => null,
+      update: async () => ({}) as any,
+    },
+    user: {
+      findMany: async () => [],
+      deleteMany: async () => ({ count: 0 }),
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async () => ({}) as any,
+      deleteMany: async () => ({ count: 0 }),
+      upsert: async () => ({}) as any,
+    },
+    orgTombstone: {
+      create: async () => ({}) as any,
+    },
+    $transaction: async <T>(run: (tx: typeof stub) => Promise<T>) => run(stub as any),
+    $queryRaw: async () => 1,
+  } as const;
+
+  return stub as unknown as PrismaClient;
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; font-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
+    />
     <title>APGMS Pro+</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- gate API requests behind an ALLOWED_ORIGINS allowlist and add request hook fallback for disallowed origins
- apply reusable security headers plugin with CSP matching the frontend meta tag
- extend the webapp HTML with a CSP meta tag and add Fastify inject tests covering CORS and CSP behaviour

## Testing
- pnpm --filter @apgms/api-gateway exec tsx --test test/security.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f795af8d548327b6342c785413aa2a