### PR TITLE
Add metrics endpoint and graceful shutdown to API gateway

### DIFF
--- a/runbooks/api-gateway-observability.md
+++ b/runbooks/api-gateway-observability.md
@@ -1,0 +1,26 @@
+# API Gateway Observability & Operations
+
+## Runtime endpoints
+
+| Endpoint   | Description |
+| ---------- | ----------- |
+| `GET /health`  | Liveness probe that reports the service name and indicates that the Fastify instance is running. |
+| `GET /ready`   | Readiness probe that checks required dependencies. The response body is `{ ready: boolean, dependencies: { database: boolean, queue: boolean } }`. If any dependency fails, the route returns `503`. |
+| `GET /metrics` | Exposes Prometheus-formatted metrics including default process stats, HTTP request duration histograms, and Prisma database timings. |
+
+## Metrics
+
+Metrics are collected through a lightweight Prometheus client that is registered when the server boots. Default process statistics are exported with the `apgms_` prefix. Custom histograms provide insight into:
+
+- `apgms_http_request_duration_seconds{method,route,status_code}` for Fastify handler timings.
+- `apgms_db_query_duration_seconds{model,action}` for Prisma query durations.
+
+## Shutdown behaviour
+
+The Fastify bootstrap (`src/index.ts`) listens for `SIGTERM` and `SIGINT`. When either signal is received the server:
+
+1. Logs the signal receipt for traceability.
+2. Awaits `app.close()` to drain connections and run registered `onClose` hooks (including disconnecting Prisma and closing the queue client when applicable).
+3. Exits with code `0` on success or `1` if shutdown throws.
+
+Kubernetes or process supervisors should rely on the readiness endpoint before terminating pods to ensure dependent workloads continue to function.

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -13,7 +13,8 @@
     "@prisma/client": "6.17.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "prom-client": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -15,6 +15,22 @@ app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
+const handleSignal = (signal: NodeJS.Signals) => {
+  app.log.info({ signal }, "received shutdown signal");
+  void (async () => {
+    try {
+      await app.close();
+      process.exit(0);
+    } catch (err) {
+      app.log.error({ err }, "error during shutdown");
+      process.exit(1);
+    }
+  })();
+};
+
+process.once("SIGINT", handleSignal);
+process.once("SIGTERM", handleSignal);
+
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 

--- a/services/api-gateway/src/lib/metrics.ts
+++ b/services/api-gateway/src/lib/metrics.ts
@@ -1,0 +1,75 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { collectDefaultMetrics, Histogram, Registry } from "prom-client";
+
+import type { PrismaLike } from "../app";
+
+export interface MetricsContext {
+  registry: Registry;
+}
+
+const PRISMA_METRICS_FLAG = Symbol.for("apgms.metrics.prisma");
+
+function routeLabel(request: FastifyRequest): string {
+  const route = (request.routeOptions && request.routeOptions.url) || (request as any).routerPath;
+  return typeof route === "string" ? route : request.url;
+}
+
+export function setupMetrics(app: FastifyInstance, prisma: PrismaLike): MetricsContext {
+  const registry = new Registry();
+  collectDefaultMetrics({ register: registry, prefix: "apgms_" });
+
+  const httpHistogram = new Histogram({
+    name: "apgms_http_request_duration_seconds",
+    help: "Duration of HTTP requests handled by the API gateway.",
+    labelNames: ["method", "route", "status_code"],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    registers: [registry],
+  });
+
+  const dbHistogram = new Histogram({
+    name: "apgms_db_query_duration_seconds",
+    help: "Duration of Prisma database queries in seconds.",
+    labelNames: ["model", "action"],
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+    registers: [registry],
+  });
+
+  app.addHook("onRequest", (request, _reply, done) => {
+    (request as any).__metricsStart = process.hrtime.bigint();
+    done();
+  });
+
+  app.addHook("onResponse", (request, reply, done) => {
+    const start = (request as any).__metricsStart as bigint | undefined;
+    if (typeof start === "bigint") {
+      const diff = process.hrtime.bigint() - start;
+      const seconds = Number(diff) / 1e9;
+      httpHistogram.observe(
+        {
+          method: request.method,
+          route: routeLabel(request),
+          status_code: reply.statusCode,
+        },
+        seconds
+      );
+    }
+    done();
+  });
+
+  const prismaAny = prisma as PrismaLike & { [PRISMA_METRICS_FLAG]?: boolean };
+  if (!prismaAny[PRISMA_METRICS_FLAG] && typeof prisma.$use === "function") {
+    prismaAny[PRISMA_METRICS_FLAG] = true;
+    prisma.$use?.(async (params, next) => {
+      const model = params.model ?? "raw";
+      const action = params.action ?? params.clientMethod ?? "query";
+      const stopTimer = dbHistogram.startTimer({ model, action });
+      try {
+        return await next(params);
+      } finally {
+        stopTimer();
+      }
+    });
+  }
+
+  return { registry };
+}

--- a/services/api-gateway/src/lib/queue.ts
+++ b/services/api-gateway/src/lib/queue.ts
@@ -1,0 +1,82 @@
+import net from "node:net";
+import { URL } from "node:url";
+
+export interface QueueClient {
+  ping(): Promise<void>;
+  close?(): Promise<void>;
+}
+
+let cachedQueue: QueueClient | null = null;
+
+function resolveRedisUrl(): URL {
+  const raw = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
+  try {
+    return new URL(raw);
+  } catch (err) {
+    throw new Error(`Invalid REDIS_URL provided: ${raw}`);
+  }
+}
+
+class RedisQueueClient implements QueueClient {
+  private readonly url: URL;
+
+  constructor(url: URL) {
+    this.url = url;
+  }
+
+  async ping(): Promise<void> {
+    const port = this.url.port ? Number(this.url.port) : 6379;
+    const host = this.url.hostname;
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = net.createConnection({ host, port }, () => {
+        socket.write("PING\r\n");
+      });
+
+      socket.setTimeout(3000);
+
+      let buffer = "";
+
+      const cleanup = () => {
+        socket.removeAllListeners();
+        socket.destroy();
+      };
+
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        if (buffer.includes("+PONG")) {
+          cleanup();
+          resolve();
+        }
+      });
+
+      socket.on("timeout", () => {
+        cleanup();
+        reject(new Error("Redis ping timed out"));
+      });
+
+      socket.on("error", (err) => {
+        cleanup();
+        reject(err);
+      });
+
+      socket.on("end", () => {
+        if (!buffer.includes("+PONG")) {
+          cleanup();
+          reject(new Error("Redis ping did not return PONG"));
+        }
+      });
+    });
+  }
+}
+
+export async function loadDefaultQueue(): Promise<QueueClient> {
+  if (!cachedQueue) {
+    cachedQueue = new RedisQueueClient(resolveRedisUrl());
+  }
+  return cachedQueue;
+}
+
+export function setQueueClient(client: QueueClient | null): void {
+  cachedQueue = client;
+}

--- a/services/api-gateway/test/ready.spec.ts
+++ b/services/api-gateway/test/ready.spec.ts
@@ -1,15 +1,31 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createApp } from "../src/app";
+import type { QueueClient } from "../src/lib/queue";
 import { prisma } from "@apgms/shared/db";
 
 let app: Awaited<ReturnType<typeof createApp>>;
 describe("/ready", () => {
-  beforeAll(async () => { app = await createApp(); await app.ready(); });
+  const healthyQueue: QueueClient = {
+    async ping() {
+      return Promise.resolve();
+    },
+  };
+
+  beforeAll(async () => {
+    app = await createApp({ queue: healthyQueue });
+    await app.ready();
+  });
   afterAll(async () => { await app.close(); await prisma.$disconnect(); });
 
   it("returns 200 when DB is reachable", async () => {
     const res = await app.inject({ method: "GET", url: "/ready" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ ready: true });
+    expect(res.json()).toEqual({
+      ready: true,
+      dependencies: {
+        database: true,
+        queue: true,
+      },
+    });
   });
 });

--- a/services/prom-client/package.json
+++ b/services/prom-client/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "prom-client",
+  "version": "0.1.0-apgms",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/services/prom-client/src/index.ts
+++ b/services/prom-client/src/index.ts
@@ -1,0 +1,183 @@
+import os from "node:os";
+
+export type Labels = Record<string, string | number>;
+
+type MetricCollector = () => string | Promise<string>;
+
+function formatLabelValue(value: string | number): string {
+  return String(value).replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+export class Registry {
+  private collectors: MetricCollector[] = [];
+
+  registerMetric(collector: MetricCollector): void {
+    this.collectors.push(collector);
+  }
+
+  async metrics(): Promise<string> {
+    const parts = await Promise.all(this.collectors.map(async (collector) => collector()));
+    return parts.filter(Boolean).join("\n\n");
+  }
+
+  get contentType(): string {
+    return "text/plain; version=0.0.4; charset=utf-8";
+  }
+}
+
+export const register = new Registry();
+
+export interface HistogramConfiguration {
+  name: string;
+  help: string;
+  labelNames?: string[];
+  buckets?: number[];
+  registers?: Registry[];
+}
+
+interface HistogramRecord {
+  labels: Labels;
+  buckets: number[];
+  counts: number[];
+  sum: number;
+  observations: number;
+}
+
+const DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+
+function createLabelKey(labelNames: string[], labels: Labels): string {
+  return labelNames
+    .map((name) => `${name}:${labels[name] ?? ""}`)
+    .join("|");
+}
+
+function sanitizeLabels(labelNames: string[] | undefined, labels: Labels): Labels {
+  if (!labelNames || labelNames.length === 0) {
+    return {};
+  }
+  const sanitized: Labels = {};
+  for (const name of labelNames) {
+    const value = labels[name];
+    sanitized[name] = value === undefined ? "" : value;
+  }
+  return sanitized;
+}
+
+export class Histogram {
+  private readonly labelNames: string[];
+  private readonly buckets: number[];
+  private readonly records = new Map<string, HistogramRecord>();
+
+  constructor(private readonly config: HistogramConfiguration) {
+    this.labelNames = config.labelNames ?? [];
+    this.buckets = [...(config.buckets ?? DEFAULT_BUCKETS)].sort((a, b) => a - b);
+
+    const registries = config.registers && config.registers.length > 0 ? config.registers : [register];
+    for (const reg of registries) {
+      reg.registerMetric(() => this.serialize());
+    }
+  }
+
+  observe(labels: Labels, value: number): void {
+    const sanitized = sanitizeLabels(this.labelNames, labels);
+    const key = createLabelKey(this.labelNames, sanitized);
+    const existing = this.records.get(key);
+    const record = existing ?? {
+      labels: sanitized,
+      buckets: this.buckets,
+      counts: new Array(this.buckets.length).fill(0),
+      sum: 0,
+      observations: 0,
+    };
+
+    for (let index = 0; index < this.buckets.length; index += 1) {
+      if (value <= this.buckets[index]) {
+        record.counts[index] += 1;
+      }
+    }
+
+    record.sum += value;
+    record.observations += 1;
+
+    this.records.set(key, record);
+  }
+
+  startTimer(baseLabels: Labels = {}): (labels?: Labels) => number {
+    const start = process.hrtime.bigint();
+    return (labels: Labels = {}) => {
+      const end = process.hrtime.bigint();
+      const durationSeconds = Number(end - start) / 1e9;
+      this.observe({ ...baseLabels, ...labels }, durationSeconds);
+      return durationSeconds;
+    };
+  }
+
+  private serialize(): string {
+    const lines: string[] = [];
+    lines.push(`# HELP ${this.config.name} ${this.config.help}`);
+    lines.push(`# TYPE ${this.config.name} histogram`);
+
+    for (const record of this.records.values()) {
+      for (let index = 0; index < record.buckets.length; index += 1) {
+        const le = record.buckets[index];
+        const labels = this.formatLabels({ ...record.labels, le });
+        lines.push(`${this.config.name}_bucket${labels} ${record.counts[index]}`);
+      }
+      const labelsInf = this.formatLabels({ ...record.labels, le: "+Inf" });
+      lines.push(`${this.config.name}_bucket${labelsInf} ${record.observations}`);
+      lines.push(`${this.config.name}_sum${this.formatLabels(record.labels)} ${record.sum}`);
+      lines.push(`${this.config.name}_count${this.formatLabels(record.labels)} ${record.observations}`);
+    }
+
+    return lines.join("\n");
+  }
+
+  private formatLabels(labels: Labels): string {
+    const entries = Object.entries(labels);
+    if (entries.length === 0) {
+      return "";
+    }
+    const rendered = entries
+      .map(([key, value]) => `${key}="${formatLabelValue(value)}"`)
+      .join(",");
+    return `{${rendered}}`;
+  }
+}
+
+export interface DefaultMetricsOptions {
+  register?: Registry;
+  prefix?: string;
+}
+
+export function collectDefaultMetrics(options: DefaultMetricsOptions = {}): void {
+  const targetRegistry = options.register ?? register;
+  const prefix = options.prefix ?? "";
+
+  targetRegistry.registerMetric(() => {
+    const uptime = process.uptime();
+    const memory = process.memoryUsage();
+    const load = os.loadavg();
+
+    const metrics: string[] = [];
+
+    metrics.push(`# HELP ${prefix}process_uptime_seconds Process uptime in seconds.`);
+    metrics.push(`# TYPE ${prefix}process_uptime_seconds gauge`);
+    metrics.push(`${prefix}process_uptime_seconds ${uptime}`);
+
+    metrics.push(`# HELP ${prefix}process_heap_used_bytes Process heap used in bytes.`);
+    metrics.push(`# TYPE ${prefix}process_heap_used_bytes gauge`);
+    metrics.push(`${prefix}process_heap_used_bytes ${memory.heapUsed}`);
+
+    metrics.push(`# HELP ${prefix}process_rss_bytes Resident set size in bytes.`);
+    metrics.push(`# TYPE ${prefix}process_rss_bytes gauge`);
+    metrics.push(`${prefix}process_rss_bytes ${memory.rss}`);
+
+    metrics.push(`# HELP ${prefix}process_load_average Load average over 1m, 5m, 15m.`);
+    metrics.push(`# TYPE ${prefix}process_load_average gauge`);
+    metrics.push(`${prefix}process_load_average{window="1"} ${load[0] ?? 0}`);
+    metrics.push(`${prefix}process_load_average{window="5"} ${load[1] ?? 0}`);
+    metrics.push(`${prefix}process_load_average{window="15"} ${load[2] ?? 0}`);
+
+    return metrics.join("\n");
+  });
+}


### PR DESCRIPTION
## Summary
- add a lightweight prom-client workspace package and hook Fastify/Prisma metrics into a /metrics endpoint
- extend readiness checks to verify the database and Redis queue while closing dependencies during shutdown
- handle SIGTERM/SIGINT for graceful shutdown and document health/metrics endpoints for operators

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f795af148483279250f4b23199129b