### PR TITLE
Add comprehensive security scanning workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,156 @@
-﻿name: Security
-on: [push]
+name: Security
+
+on:
+  push:
+  pull_request:
+
 jobs:
-  scan:
+  sbom:
+    name: Generate SBOM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: echo scanning
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p artifacts
+          pnpm dlx @cyclonedx/cyclonedx-npm --output-format json --output-file artifacts/cyclonedx-sbom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cyclonedx-sbom
+          path: artifacts/cyclonedx-sbom.json
+
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pnpm audit
+        run: |
+          mkdir -p artifacts
+          set -o pipefail
+          status=0
+          pnpm audit --prod --audit-level=high --json > artifacts/pnpm-audit.json || status=$?
+          if [ ! -s artifacts/pnpm-audit.json ]; then
+            echo '{}' > artifacts/pnpm-audit.json
+          fi
+          echo "AUDIT_EXIT_CODE=$status" >> "$GITHUB_ENV"
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pnpm-audit
+          path: artifacts/pnpm-audit.json
+
+      - name: Fail on audit findings
+        if: env.AUDIT_EXIT_CODE != '0'
+        run: |
+          echo "High severity vulnerabilities detected by pnpm audit."
+          exit 1
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Gitleaks
+        run: |
+          mkdir -p artifacts
+          status=0
+          docker run --rm \
+            -v "$PWD:/repo" \
+            zricethezav/gitleaks:latest detect \
+            --source=/repo \
+            --report-path=/repo/artifacts/gitleaks-report.json \
+            --report-format=json || status=$?
+          if [ ! -s artifacts/gitleaks-report.json ]; then
+            echo '{}' > artifacts/gitleaks-report.json
+          fi
+          echo "GITLEAKS_EXIT_CODE=$status" >> "$GITHUB_ENV"
+
+      - name: Upload Gitleaks report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: artifacts/gitleaks-report.json
+
+      - name: Fail on leaked secrets
+        if: env.GITLEAKS_EXIT_CODE != '0'
+        run: |
+          echo "Gitleaks detected potential secrets. See report for details."
+          exit 1
+
+  vulnerability-scan:
+    name: Trivy File System Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy FS scan
+        run: |
+          mkdir -p artifacts
+          status=0
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            aquasec/trivy:0.49.1 fs \
+            --format json \
+            --output /workspace/artifacts/trivy-fs-report.json \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            /workspace || status=$?
+          if [ ! -s artifacts/trivy-fs-report.json ]; then
+            echo '{}' > artifacts/trivy-fs-report.json
+          fi
+          echo "TRIVY_EXIT_CODE=$status" >> "$GITHUB_ENV"
+
+      - name: Upload Trivy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-fs-report
+          path: artifacts/trivy-fs-report.json
+
+      - name: Fail on Trivy findings
+        if: env.TRIVY_EXIT_CODE != '0'
+        run: |
+          echo "Trivy detected high or critical vulnerabilities. See report for details."
+          exit 1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,74 @@
-﻿# Security Policy
+# Security Policy
+
 Email: security@yourdomain.example
+
+## Running security scans locally
+
+The automated security workflow runs several tools that you can execute locally before opening a pull request.
+
+### Prerequisites
+- [pnpm](https://pnpm.io/) (after installing Node.js 18 or newer)
+- [Docker](https://docs.docker.com/get-docker/) for container-based scanners
+
+Install project dependencies once before running the pnpm-based commands:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+### Generate a CycloneDX SBOM
+
+```bash
+pnpm dlx @cyclonedx/cyclonedx-npm --output-format json --output-file artifacts/cyclonedx-sbom.json
+```
+
+The command creates a CycloneDX JSON bill of materials at `artifacts/cyclonedx-sbom.json`. The process exits with a non-zero status if SBOM generation fails.
+
+### Run the dependency audit
+
+```bash
+pnpm audit --prod --audit-level=high --json > artifacts/pnpm-audit.json
+```
+
+This audit fails with exit code `1` when high or critical vulnerabilities are found. Review `artifacts/pnpm-audit.json` for the detailed report.
+
+### Scan for secrets with Gitleaks
+
+```bash
+mkdir -p artifacts
+status=0
+docker run --rm \
+  -v "$(pwd):/repo" \
+  zricethezav/gitleaks:latest detect \
+  --source=/repo \
+  --report-path=/repo/artifacts/gitleaks-report.json \
+  --report-format=json || status=$?
+if [ ! -s artifacts/gitleaks-report.json ]; then
+  echo '{}' > artifacts/gitleaks-report.json
+fi
+exit "$status"
+```
+
+Gitleaks exits with status `1` when potential secrets are detected. The JSON report is stored at `artifacts/gitleaks-report.json`.
+
+### Run the Trivy file system scan
+
+```bash
+mkdir -p artifacts
+status=0
+docker run --rm \
+  -v "$(pwd):/workspace" \
+  -w /workspace \
+  aquasec/trivy:0.49.1 fs \
+  --format json \
+  --output /workspace/artifacts/trivy-fs-report.json \
+  --severity HIGH,CRITICAL \
+  --exit-code 1 \
+  /workspace || status=$?
+if [ ! -s artifacts/trivy-fs-report.json ]; then
+  echo '{}' > artifacts/trivy-fs-report.json
+fi
+exit "$status"
+```
+
+Trivy returns exit code `1` when high or critical vulnerabilities are detected. Inspect `artifacts/trivy-fs-report.json` for findings.


### PR DESCRIPTION
## Summary
- add a security workflow that generates a CycloneDX SBOM, audits dependencies, scans for secrets, and runs Trivy FS scanning with artifact uploads and failure gates
- document how to run the SBOM generation, dependency audit, secret scan, and Trivy scan locally in the security policy

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68f795ad23b48327889aa5c0e77a4111