### PR TITLE
Add JWT auth for API gateway routes

### DIFF
--- a/services/api-gateway/src/auth.ts
+++ b/services/api-gateway/src/auth.ts
@@ -1,0 +1,168 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+
+import { maskError } from "@apgms/shared";
+
+type JwtClaims = {
+  sub?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  orgId?: string;
+  email?: string;
+  [key: string]: unknown;
+};
+
+const ClaimsSchema = z.object({
+  sub: z.string().min(1),
+  orgId: z.string().min(1),
+  email: z.string().email().optional(),
+});
+
+export interface AuthContext {
+  userId: string;
+  orgId: string;
+  email: string | null;
+  claims: JwtClaims;
+}
+
+type PrismaLike = Pick<PrismaClient, "user">;
+
+declare module "fastify" {
+  interface FastifyRequest {
+    principal: AuthContext | null;
+  }
+}
+
+export interface AuthVerifierOptions {
+  issuer: string;
+  audience: string;
+  secret: string;
+  prisma: PrismaLike;
+}
+
+export function createAuthVerifier(options: AuthVerifierOptions) {
+  const { issuer, audience, secret, prisma } = options;
+  if (!secret) {
+    throw new Error("AUTH_JWT_SECRET is not configured");
+  }
+  if (!issuer) {
+    throw new Error("AUTH_JWT_ISSUER is not configured");
+  }
+  if (!audience) {
+    throw new Error("AUTH_JWT_AUDIENCE is not configured");
+  }
+
+  return async function requireAuth(req: FastifyRequest, reply: FastifyReply) {
+    req.principal = null;
+
+    const header = req.headers.authorization;
+    if (!header || (Array.isArray(header) ? header.length === 0 : false)) {
+      await reply.code(401).send({ error: "unauthenticated" });
+      return reply;
+    }
+
+    const value = Array.isArray(header) ? header[0] : header;
+    const token = value.startsWith("Bearer ") ? value.slice(7).trim() : "";
+    if (!token) {
+      await reply.code(401).send({ error: "unauthenticated" });
+      return reply;
+    }
+
+    let payload: JwtClaims;
+    try {
+      payload = verifyJwt(token, secret, issuer, audience);
+    } catch (err) {
+      req.log.warn({ err: maskError(err) }, "failed to verify jwt");
+      await reply.code(401).send({ error: "unauthenticated" });
+      return reply;
+    }
+
+    const parsed = ClaimsSchema.safeParse(payload);
+    if (!parsed.success) {
+      req.log.warn({ err: parsed.error.flatten() }, "jwt missing required claims");
+      await reply.code(403).send({ error: "forbidden" });
+      return reply;
+    }
+
+    const { sub, orgId, email } = parsed.data;
+    const user = await prisma.user.findUnique({
+      where: { id: sub },
+      select: { id: true, email: true, orgId: true },
+    });
+
+    if (!user || user.orgId !== orgId) {
+      await reply.code(403).send({ error: "forbidden" });
+      return reply;
+    }
+
+    req.principal = {
+      userId: user.id,
+      orgId: user.orgId,
+      email: user.email,
+      claims: payload,
+    };
+  };
+}
+
+function verifyJwt(token: string, secret: string, issuer: string, audience: string): JwtClaims {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("invalid_token");
+  }
+  const [headerSegment, payloadSegment, signatureSegment] = parts;
+
+  let header: { alg?: string };
+  try {
+    header = JSON.parse(Buffer.from(headerSegment, "base64url").toString("utf8"));
+  } catch (err) {
+    throw new Error("invalid_token_header");
+  }
+  if (header.alg !== "HS256") {
+    throw new Error("unsupported_algorithm");
+  }
+
+  const payloadBuffer = Buffer.from(payloadSegment, "base64url");
+  let claims: JwtClaims;
+  try {
+    claims = JSON.parse(payloadBuffer.toString("utf8"));
+  } catch (err) {
+    throw new Error("invalid_token_payload");
+  }
+
+  const expectedSignature = createHmac("sha256", Buffer.from(secret, "utf8"))
+    .update(`${headerSegment}.${payloadSegment}`)
+    .digest();
+  const providedSignature = Buffer.from(signatureSegment, "base64url");
+  if (expectedSignature.length !== providedSignature.length) {
+    throw new Error("invalid_signature");
+  }
+  if (!timingSafeEqual(expectedSignature, providedSignature)) {
+    throw new Error("invalid_signature");
+  }
+
+  if (claims.iss !== issuer) {
+    throw new Error("invalid_issuer");
+  }
+
+  const audClaim = claims.aud;
+  const matchesAudience = Array.isArray(audClaim)
+    ? audClaim.includes(audience)
+    : audClaim === audience;
+  if (!matchesAudience) {
+    throw new Error("invalid_audience");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof claims.exp !== "number" || claims.exp <= now) {
+    throw new Error("token_expired");
+  }
+  if (claims.nbf !== undefined && typeof claims.nbf === "number" && claims.nbf > now) {
+    throw new Error("token_not_ready");
+  }
+
+  return claims;
+}

--- a/services/api-gateway/test/authenticated.routes.spec.ts
+++ b/services/api-gateway/test/authenticated.routes.spec.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { createHmac } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import type { BankLine, Org, PrismaClient, User } from "@prisma/client";
+
+import { createApp } from "../src/app";
+import { createPrismaStub, type Stub } from "./helpers/prisma-stub";
+
+const AUTH_SECRET = "test-auth-secret";
+const AUTH_ISSUER = "https://issuer.example.com";
+const AUTH_AUDIENCE = "apgms-api";
+const ADMIN_TOKEN = "test-admin-token";
+
+let app: FastifyInstance;
+let stub: Stub;
+
+beforeEach(async () => {
+  process.env.AUTH_JWT_SECRET = AUTH_SECRET;
+  process.env.AUTH_JWT_ISSUER = AUTH_ISSUER;
+  process.env.AUTH_JWT_AUDIENCE = AUTH_AUDIENCE;
+  process.env.ADMIN_TOKEN = ADMIN_TOKEN;
+
+  stub = createPrismaStub();
+  app = await createApp({ prisma: stub.client as unknown as PrismaClient });
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+test("/users requires authentication", async () => {
+  const response = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(response.statusCode, 401);
+});
+
+test("/bank-lines requires authentication", async () => {
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(response.statusCode, 401);
+});
+
+test("/users returns 403 when the user is unknown", async () => {
+  const token = await buildToken({ sub: "missing", orgId: "org-1", email: "missing@example.com" });
+  const response = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  assert.equal(response.statusCode, 403);
+});
+
+test("/users only returns users from the caller's organisation", async () => {
+  seedOrg("org-1", "Org One");
+  seedOrg("org-2", "Org Two");
+  const firstCreated = new Date("2024-01-01T00:00:00Z");
+  const secondCreated = new Date("2023-01-01T00:00:00Z");
+  seedUser({ id: "user-1", email: "user1@example.com", orgId: "org-1", createdAt: firstCreated });
+  seedUser({ id: "user-2", email: "user2@example.com", orgId: "org-2", createdAt: secondCreated });
+
+  const token = await buildToken({ sub: "user-1", orgId: "org-1", email: "user1@example.com" });
+  const response = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as { users: Array<{ id: string; email: string; createdAt: string }> };
+  assert.deepEqual(body.users, [
+    {
+      id: "user-1",
+      email: "user1@example.com",
+      createdAt: firstCreated.toISOString(),
+    },
+  ]);
+});
+
+test("/bank-lines only returns lines for the caller's organisation", async () => {
+  seedOrg("org-1", "Org One");
+  seedOrg("org-2", "Org Two");
+  seedUser({ id: "user-1", email: "user1@example.com", orgId: "org-1" });
+  seedLine({
+    id: "line-1",
+    orgId: "org-1",
+    date: new Date("2024-03-03T00:00:00Z"),
+    amount: 1200 as any,
+    payee: "Vendor A",
+    desc: "Invoice",
+  });
+  seedLine({
+    id: "line-2",
+    orgId: "org-2",
+    date: new Date("2024-02-02T00:00:00Z"),
+    amount: 900 as any,
+    payee: "Vendor B",
+    desc: "Invoice",
+  });
+
+  const token = await buildToken({ sub: "user-1", orgId: "org-1", email: "user1@example.com" });
+  const response = await app.inject({
+    method: "GET",
+    url: "/bank-lines",
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as { lines: Array<{ id: string; orgId: string }> };
+  assert.equal(body.lines.length, 1);
+  assert.equal(body.lines[0].id, "line-1");
+  assert.equal(body.lines[0].orgId, "org-1");
+});
+
+test("/bank-lines rejects mismatched organisation IDs in the payload", async () => {
+  seedOrg("org-1", "Org One");
+  seedOrg("org-2", "Org Two");
+  seedUser({ id: "user-1", email: "user1@example.com", orgId: "org-1" });
+
+  const token = await buildToken({ sub: "user-1", orgId: "org-1", email: "user1@example.com" });
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { authorization: `Bearer ${token}` },
+    payload: {
+      orgId: "org-2",
+      date: new Date("2024-04-01T00:00:00Z").toISOString(),
+      amount: "100.00",
+      payee: "Other",
+      desc: "Mismatch",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+});
+
+test("/bank-lines creates a new line for the caller's organisation", async () => {
+  seedOrg("org-1", "Org One");
+  seedUser({ id: "user-1", email: "user1@example.com", orgId: "org-1" });
+
+  const token = await buildToken({ sub: "user-1", orgId: "org-1", email: "user1@example.com" });
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { authorization: `Bearer ${token}` },
+    payload: {
+      date: new Date("2024-05-05T00:00:00Z").toISOString(),
+      amount: "42.50",
+      payee: "Cafe",
+      desc: "Lunch",
+    },
+  });
+
+  assert.equal(response.statusCode, 201);
+  const body = response.json() as { orgId: string; payee: string; idempotencyKey: string | null };
+  assert.equal(body.orgId, "org-1");
+  assert.equal(body.payee, "Cafe");
+  assert.equal(body.idempotencyKey, null);
+  assert.equal(stub.state.bankLines.length, 1);
+  assert.equal(stub.state.bankLines[0].orgId, "org-1");
+});
+
+test("/bank-lines honours idempotency keys", async () => {
+  seedOrg("org-1", "Org One");
+  seedUser({ id: "user-1", email: "user1@example.com", orgId: "org-1" });
+
+  const token = await buildToken({ sub: "user-1", orgId: "org-1", email: "user1@example.com" });
+  const payload = {
+    date: new Date("2024-06-06T00:00:00Z").toISOString(),
+    amount: "99.00",
+    payee: "Supplier",
+    desc: "Subscription",
+  };
+  const headers = {
+    authorization: `Bearer ${token}`,
+    "idempotency-key": "unique-key-123",
+  } as const;
+
+  const first = await app.inject({ method: "POST", url: "/bank-lines", headers, payload });
+  assert.equal(first.statusCode, 200);
+  assert.equal(stub.state.bankLines.length, 1);
+
+  const second = await app.inject({ method: "POST", url: "/bank-lines", headers, payload });
+  assert.equal(second.statusCode, 200);
+  assert.equal(second.headers["idempotency-status"], "reused");
+  const firstBody = first.json();
+  const secondBody = second.json();
+  assert.deepEqual(secondBody, firstBody);
+  assert.equal(stub.state.bankLines.length, 1);
+});
+
+async function buildToken(claims: { sub: string; orgId: string; email?: string }) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = {
+    sub: claims.sub,
+    orgId: claims.orgId,
+    email: claims.email,
+    iss: AUTH_ISSUER,
+    aud: AUTH_AUDIENCE,
+    iat: now,
+    exp: now + 300,
+  };
+  const headerSegment = Buffer.from(JSON.stringify(header)).toString("base64url");
+  const payloadSegment = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", Buffer.from(AUTH_SECRET, "utf8"))
+    .update(`${headerSegment}.${payloadSegment}`)
+    .digest("base64url");
+  return `${headerSegment}.${payloadSegment}.${signature}`;
+}
+
+function seedOrg(id: string, name: string) {
+  stub.state.orgs.push({
+    id,
+    name,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    deletedAt: null,
+  } as Org & { deletedAt: Date | null });
+}
+
+function seedUser({ id, email, orgId, createdAt }: { id: string; email: string; orgId: string; createdAt?: Date }) {
+  stub.state.users.push({
+    id,
+    email,
+    password: "hashed-password",
+    orgId,
+    createdAt: createdAt ?? new Date("2024-01-01T00:00:00Z"),
+  } as User);
+}
+
+function seedLine(line: { id: string; orgId: string; date: Date; amount: any; payee: string; desc: string }) {
+  stub.state.bankLines.push({
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date,
+    amount: line.amount,
+    payee: line.payee,
+    desc: line.desc,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    idempotencyKey: null,
+  } as BankLine);
+}

--- a/services/api-gateway/test/helpers/prisma-stub.ts
+++ b/services/api-gateway/test/helpers/prisma-stub.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import type { BankLine, Org, PrismaClient, User } from "@prisma/client";
+
+export type OrgState = Org & { deletedAt: Date | null };
+
+export type State = {
+  orgs: OrgState[];
+  users: User[];
+  bankLines: BankLine[];
+  tombstones: Array<{ id: string; orgId: string; payload: unknown; createdAt: Date }>;
+};
+
+type TransactionCallback<T> = (tx: PrismaLike) => Promise<T>;
+
+type UserSelect = { [K in keyof User]?: boolean };
+type BankLineSelect = { [K in keyof BankLine]?: boolean };
+
+type UserFindManyArgs = {
+  where?: { orgId?: string };
+  orderBy?: { createdAt?: "asc" | "desc" };
+  select?: UserSelect;
+};
+
+type UserFindUniqueArgs = {
+  where: { id: string };
+  select?: UserSelect;
+};
+
+type BankLineFindManyArgs = {
+  where?: { orgId?: string };
+  orderBy?: { date?: "asc" | "desc" };
+  take?: number;
+  select?: BankLineSelect;
+};
+
+type BankLineCreateArgs = {
+  data: {
+    orgId: string;
+    date: Date;
+    amount: unknown;
+    payee: string;
+    desc: string;
+    idempotencyKey?: string | null;
+  };
+  select?: BankLineSelect;
+};
+
+type BankLineUpsertArgs = {
+  where: { orgId_idempotencyKey: { orgId: string; idempotencyKey: string } };
+  create: BankLineCreateArgs["data"];
+  update: Partial<BankLine>;
+  select?: BankLineSelect;
+};
+
+type BankLineDeleteManyArgs = { where?: { orgId?: string } };
+
+type UserDeleteManyArgs = { where?: { orgId?: string } };
+
+type OrgFindUniqueArgs = {
+  where: { id: string };
+  include?: { users?: boolean; lines?: boolean };
+};
+
+type OrgUpdateArgs = { where: { id: string }; data: Partial<OrgState> };
+
+type OrgTombstoneCreateArgs = {
+  data: { id?: string; orgId: string; payload: unknown; createdAt?: Date };
+};
+
+export type PrismaLike = Pick<
+  PrismaClient,
+  "$transaction"
+> & {
+  org: {
+    findUnique: (args: OrgFindUniqueArgs) => Promise<OrgState | (OrgState & { users: User[]; lines: BankLine[] }) | null>;
+    update: (args: OrgUpdateArgs) => Promise<OrgState>;
+  };
+  user: {
+    findMany: (args: UserFindManyArgs) => Promise<Array<Partial<User>>>;
+    findUnique: (args: UserFindUniqueArgs) => Promise<Partial<User> | null>;
+    deleteMany: (args: UserDeleteManyArgs) => Promise<{ count: number }>;
+  };
+  bankLine: {
+    findMany: (args: BankLineFindManyArgs) => Promise<Array<Partial<BankLine>>>;
+    create: (args: BankLineCreateArgs) => Promise<Partial<BankLine>>;
+    upsert: (args: BankLineUpsertArgs) => Promise<Partial<BankLine>>;
+    deleteMany: (args: BankLineDeleteManyArgs) => Promise<{ count: number }>;
+  };
+  orgTombstone: {
+    create: (args: OrgTombstoneCreateArgs) => Promise<{ id: string; orgId: string; payload: unknown; createdAt: Date }>;
+  };
+};
+
+export type Stub = { client: PrismaLike; state: State };
+
+export function createPrismaStub(initial?: Partial<State>): Stub {
+  const state: State = {
+    orgs: initial?.orgs ?? [],
+    users: initial?.users ?? [],
+    bankLines: initial?.bankLines ?? [],
+    tombstones: initial?.tombstones ?? [],
+  };
+
+  const client: PrismaLike = {
+    org: {
+      findUnique: async ({ where, include }) => {
+        const org = state.orgs.find((o) => o.id === where.id);
+        if (!org) return null;
+        if (include?.users || include?.lines) {
+          return {
+            ...org,
+            users: include?.users ? state.users.filter((user) => user.orgId === org.id) : [],
+            lines: include?.lines ? state.bankLines.filter((line) => line.orgId === org.id) : [],
+          } as OrgState & { users: User[]; lines: BankLine[] };
+        }
+        return { ...org };
+      },
+      update: async ({ where, data }) => {
+        const org = state.orgs.find((o) => o.id === where.id);
+        if (!org) throw new Error("Org not found");
+        Object.assign(org, data);
+        return { ...org };
+      },
+    },
+    user: {
+      findMany: async ({ where, orderBy, select } = {}) => {
+        let users = [...state.users];
+        if (where?.orgId) {
+          users = users.filter((user) => user.orgId === where.orgId);
+        }
+        if (orderBy?.createdAt === "desc") {
+          users.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+        }
+        if (select) {
+          return users.map((user) => pick(user, select));
+        }
+        return users.map((user) => ({ ...user }));
+      },
+      findUnique: async ({ where, select }) => {
+        const user = state.users.find((u) => u.id === where.id);
+        if (!user) return null;
+        if (select) {
+          return pick(user, select);
+        }
+        return { ...user };
+      },
+      deleteMany: async ({ where } = {}) => {
+        const initialLength = state.users.length;
+        state.users = state.users.filter((user) => (where?.orgId ? user.orgId !== where.orgId : true));
+        return { count: initialLength - state.users.length };
+      },
+    },
+    bankLine: {
+      findMany: async ({ where, orderBy, take, select } = {}) => {
+        let lines = [...state.bankLines];
+        if (where?.orgId) {
+          lines = lines.filter((line) => line.orgId === where.orgId);
+        }
+        if (orderBy?.date === "desc") {
+          lines.sort((a, b) => b.date.getTime() - a.date.getTime());
+        }
+        if (typeof take === "number") {
+          lines = lines.slice(0, take);
+        }
+        if (select) {
+          return lines.map((line) => pick(line, select));
+        }
+        return lines.map((line) => ({ ...line }));
+      },
+      create: async ({ data, select }) => {
+        const created: BankLine = {
+          id: randomUUID(),
+          orgId: data.orgId,
+          date: data.date,
+          amount: data.amount as any,
+          payee: data.payee,
+          desc: data.desc,
+          createdAt: new Date(),
+          idempotencyKey: data.idempotencyKey ?? null,
+        };
+        state.bankLines.push(created);
+        if (select) {
+          return pick(created, select);
+        }
+        return { ...created };
+      },
+      upsert: async ({ where, create, update, select }) => {
+        const existing = state.bankLines.find(
+          (line) =>
+            line.orgId === where.orgId_idempotencyKey.orgId &&
+            line.idempotencyKey === where.orgId_idempotencyKey.idempotencyKey
+        );
+        if (existing) {
+          Object.assign(existing, update);
+          if (select) {
+            return pick(existing, select);
+          }
+          return { ...existing };
+        }
+        const created: BankLine = {
+          id: randomUUID(),
+          orgId: create.orgId,
+          date: create.date,
+          amount: create.amount as any,
+          payee: create.payee,
+          desc: create.desc,
+          createdAt: new Date(),
+          idempotencyKey: create.idempotencyKey ?? null,
+        };
+        state.bankLines.push(created);
+        if (select) {
+          return pick(created, select);
+        }
+        return { ...created };
+      },
+      deleteMany: async ({ where } = {}) => {
+        const initialLength = state.bankLines.length;
+        state.bankLines = state.bankLines.filter((line) => (where?.orgId ? line.orgId !== where.orgId : true));
+        return { count: initialLength - state.bankLines.length };
+      },
+    },
+    orgTombstone: {
+      create: async ({ data }) => {
+        const record = {
+          id: data.id ?? randomUUID(),
+          orgId: data.orgId,
+          payload: data.payload,
+          createdAt: data.createdAt ?? new Date(),
+        };
+        state.tombstones.push(record);
+        return record;
+      },
+    },
+    $transaction: async <T>(callback: TransactionCallback<T>) => {
+      return callback(client);
+    },
+  } as unknown as PrismaLike;
+
+  return { client, state };
+}
+
+export function seedOrgWithData(state: State, ids: { orgId: string; userId: string; lineId: string }) {
+  const createdAt = new Date("2024-01-01T00:00:00Z");
+  state.orgs.push({
+    id: ids.orgId,
+    name: "Example Org",
+    createdAt,
+    deletedAt: null,
+  } as OrgState);
+  state.users.push({
+    id: ids.userId,
+    email: "someone@example.com",
+    password: "hashed-password",
+    orgId: ids.orgId,
+    createdAt,
+  } as User);
+  state.bankLines.push({
+    id: ids.lineId,
+    orgId: ids.orgId,
+    date: new Date("2024-02-02T00:00:00Z"),
+    amount: 1200 as any,
+    payee: "Vendor",
+    desc: "Invoice",
+    createdAt,
+    idempotencyKey: null,
+  } as BankLine);
+}
+
+export function pick<T extends Record<string, unknown>>(value: T, select: Record<string, boolean>): Partial<T> {
+  const result: Record<string, unknown> = {};
+  for (const [key, include] of Object.entries(select)) {
+    if (include && key in (value as any)) {
+      result[key] = (value as any)[key];
+    }
+  }
+  return result as Partial<T>;
+}

--- a/services/api-gateway/test/privacy.spec.ts
+++ b/services/api-gateway/test/privacy.spec.ts
@@ -1,44 +1,29 @@
 ﻿import assert from "node:assert/strict";
 import { afterEach, beforeEach, test } from "node:test";
-import { randomUUID } from "node:crypto";
 
 import type { FastifyInstance } from "fastify";
-import type { BankLine, Org, PrismaClient, User } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 
 import { createApp, type AdminOrgExport } from "../src/app";
+import {
+  createPrismaStub,
+  seedOrgWithData,
+  type Stub,
+} from "./helpers/prisma-stub";
 
 const ADMIN_TOKEN = "test-admin-token";
-
-type OrgState = Org & { deletedAt: Date | null };
-
-type State = {
-  orgs: OrgState[];
-  users: User[];
-  bankLines: BankLine[];
-  tombstones: Array<{ id: string; orgId: string; payload: AdminOrgExport; createdAt: Date }>;
-};
-
-type TransactionCallback<T> = (tx: PrismaLike) => Promise<T>;
-
-type PrismaLike = Pick<
-  PrismaClient,
-  | "org"
-  | "user"
-  | "bankLine"
-  | "orgTombstone"
-  | "$transaction"
->;
-
-type Stub = {
-  client: PrismaLike;
-  state: State;
-};
+const AUTH_SECRET = "test-auth-secret";
+const AUTH_ISSUER = "https://issuer.example.com";
+const AUTH_AUDIENCE = "apgms-api";
 
 let app: FastifyInstance;
 let stub: Stub;
 
 beforeEach(async () => {
   process.env.ADMIN_TOKEN = ADMIN_TOKEN;
+  process.env.AUTH_JWT_SECRET = AUTH_SECRET;
+  process.env.AUTH_JWT_ISSUER = AUTH_ISSUER;
+  process.env.AUTH_JWT_AUDIENCE = AUTH_AUDIENCE;
   stub = createPrismaStub();
   app = await createApp({ prisma: stub.client as unknown as PrismaClient });
   await app.ready();
@@ -111,140 +96,11 @@ test("deleting an organisation soft-deletes data and records a tombstone", async
   assert.equal(stub.state.bankLines.filter((l) => l.orgId === "delete-me").length, 0);
   assert.equal(stub.state.tombstones.length, 1);
   const tombstone = stub.state.tombstones[0];
+  const tombstonePayload = tombstone.payload as AdminOrgExport;
   assert.equal(tombstone.orgId, "delete-me");
-  assert.equal(tombstone.payload.org.id, "delete-me");
-  assert.equal(typeof tombstone.payload.org.deletedAt, "string");
-  assert.ok(tombstone.payload.org.deletedAt && Date.parse(tombstone.payload.org.deletedAt));
+  assert.equal(tombstonePayload.org.id, "delete-me");
+  assert.equal(typeof tombstonePayload.org.deletedAt, "string");
+  assert.ok(
+    tombstonePayload.org.deletedAt && Date.parse(tombstonePayload.org.deletedAt)
+  );
 });
-
-function createPrismaStub(initial?: Partial<State>): Stub {
-  const state: State = {
-    orgs: initial?.orgs ?? [],
-    users: initial?.users ?? [],
-    bankLines: initial?.bankLines ?? [],
-    tombstones: initial?.tombstones ?? [],
-  };
-
-  const client: PrismaLike = {
-    org: {
-      findUnique: async ({ where, include }) => {
-        const org = state.orgs.find((o) => o.id === where.id);
-        if (!org) return null;
-        if (include?.users || include?.lines) {
-          return {
-            ...org,
-            users: state.users.filter((user) => user.orgId === org.id),
-            lines: state.bankLines.filter((line) => line.orgId === org.id),
-          } as unknown as Org;
-        }
-        return { ...org } as Org;
-      },
-      update: async ({ where, data }) => {
-        const org = state.orgs.find((o) => o.id === where.id);
-        if (!org) throw new Error("Org not found");
-        Object.assign(org, data);
-        return { ...org } as Org;
-      },
-    },
-    user: {
-      findMany: async ({ select, orderBy }) => {
-        let users = [...state.users];
-        if (orderBy?.createdAt === "desc") {
-          users.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-        }
-        if (select) {
-          return users.map((user) => pick(user, select));
-        }
-        return users;
-      },
-      deleteMany: async ({ where }) => {
-        const initialLength = state.users.length;
-        state.users = state.users.filter((user) => user.orgId !== where?.orgId);
-        return { count: initialLength - state.users.length };
-      },
-    },
-    bankLine: {
-      findMany: async ({ orderBy, take }) => {
-        let lines = [...state.bankLines];
-        if (orderBy?.date === "desc") {
-          lines.sort((a, b) => b.date.getTime() - a.date.getTime());
-        }
-        if (typeof take === "number") {
-          lines = lines.slice(0, take);
-        }
-        return lines;
-      },
-      create: async ({ data }) => {
-        const created = {
-          id: data.id ?? randomUUID(),
-          orgId: data.orgId!,
-          date: data.date as Date,
-          amount: data.amount as any,
-          payee: data.payee!,
-          desc: data.desc!,
-          createdAt: data.createdAt ?? new Date(),
-        } as unknown as BankLine;
-        state.bankLines.push(created);
-        return created;
-      },
-      deleteMany: async ({ where }) => {
-        const initialLength = state.bankLines.length;
-        state.bankLines = state.bankLines.filter((line) => line.orgId !== where?.orgId);
-        return { count: initialLength - state.bankLines.length };
-      },
-    },
-    orgTombstone: {
-      create: async ({ data }) => {
-        const record = {
-          id: data.id ?? randomUUID(),
-          orgId: data.orgId!,
-          payload: data.payload as AdminOrgExport,
-          createdAt: data.createdAt ?? new Date(),
-        };
-        state.tombstones.push(record);
-        return record;
-      },
-    },
-    $transaction: async <T>(callback: TransactionCallback<T>) => {
-      return callback(client);
-    },
-  } as unknown as PrismaLike;
-
-  return { client, state };
-}
-
-function seedOrgWithData(state: State, ids: { orgId: string; userId: string; lineId: string }) {
-  const createdAt = new Date("2024-01-01T00:00:00Z");
-  state.orgs.push({
-    id: ids.orgId,
-    name: "Example Org",
-    createdAt,
-    deletedAt: null,
-  } as OrgState);
-  state.users.push({
-    id: ids.userId,
-    email: "someone@example.com",
-    password: "hashed-password",
-    orgId: ids.orgId,
-    createdAt,
-  } as User);
-  state.bankLines.push({
-    id: ids.lineId,
-    orgId: ids.orgId,
-    date: new Date("2024-02-02T00:00:00Z"),
-    amount: 1200 as any,
-    payee: "Vendor",
-    desc: "Invoice",
-    createdAt,
-  } as BankLine);
-}
-
-function pick<T>(value: T, select: Record<string, boolean>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, include] of Object.entries(select)) {
-    if (include && key in (value as any)) {
-      result[key] = (value as any)[key];
-    }
-  }
-  return result;
-}

--- a/services/api-gateway/test/ready.spec.ts
+++ b/services/api-gateway/test/ready.spec.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createApp } from "../src/app";
 import { prisma } from "@apgms/shared/db";
 
+process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET ?? "test-auth-secret";
+process.env.AUTH_JWT_ISSUER = process.env.AUTH_JWT_ISSUER ?? "https://issuer.example.com";
+process.env.AUTH_JWT_AUDIENCE = process.env.AUTH_JWT_AUDIENCE ?? "apgms-api";
+process.env.ADMIN_TOKEN = process.env.ADMIN_TOKEN ?? "test-admin-token";
+
 let app: Awaited<ReturnType<typeof createApp>>;
 describe("/ready", () => {
   beforeAll(async () => { app = await createApp(); await app.ready(); });


### PR DESCRIPTION
## Summary
- add an HS256 JWT verification helper and register it on the Fastify instance
- enforce authentication and organisation scoping on /users and /bank-lines while keeping idempotent creates
- extract a reusable Prisma stub and expand tests for authenticated and admin flows

## Testing
- ./node_modules/.bin/tsx --test test/privacy.spec.ts
- ./node_modules/.bin/tsx --test test/authenticated.routes.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f795a9467c8327ace14c56149b50c0