### PR TITLE
Unify admin data routes and schemas

### DIFF
--- a/services/api-gateway/src/routes/admin.data.ts
+++ b/services/api-gateway/src/routes/admin.data.ts
@@ -1,32 +1,48 @@
-﻿<<<<<<< HEAD
 import { createHash } from "node:crypto";
 import type { FastifyInstance, FastifyRequest } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+
 import {
   adminDataDeleteRequestSchema,
   adminDataDeleteResponseSchema,
+  subjectDataExportRequestSchema,
+  subjectDataExportResponseSchema,
   type AdminDataDeleteRequest,
   type AdminDataDeleteResponse,
+  type SubjectDataExportRequest,
+  type SubjectDataExportResponse,
 } from "../schemas/admin.data";
 
 interface Principal {
   id: string;
-  role: string;
+  role: "admin" | "user";
   orgId: string;
+  email?: string;
   token: string;
 }
 
-export interface SecurityLogPayload {
-  event: "data_delete";
-  orgId: string;
-  principal: string;
-  subjectUserId: string;
-  mode: "anonymized" | "deleted";
-}
+type SecurityLogPayload =
+  | {
+      event: "data_delete";
+      orgId: string;
+      principal: string;
+      subjectUserId: string;
+      mode: "anonymized" | "deleted";
+    }
+  | {
+      event: "data_export";
+      orgId: string;
+      principal: string;
+      subjectEmail: string;
+    };
 
 const PASSWORD_PLACEHOLDER = "__deleted__";
 
 type SharedDbModule = typeof import("../../../../shared/src/db.js");
-type PrismaClientLike = Pick<SharedDbModule["prisma"], "user" | "bankLine">;
+type PrismaClientLike =
+  Pick<SharedDbModule["prisma"], "user" | "bankLine"> &
+  Partial<Pick<SharedDbModule["prisma"], "accessLog">>;
 
 interface AdminDataRouteDeps {
   prisma?: PrismaClientLike;
@@ -38,7 +54,7 @@ export async function registerAdminDataRoutes(
   deps: AdminDataRouteDeps = {}
 ) {
   const prisma = deps.prisma ?? (await getDefaultPrisma());
-  const securityLogger =
+  const securityLogger: (payload: SecurityLogPayload) => Promise<void> | void =
     deps.secLog ??
     (async (payload: SecurityLogPayload) => {
       app.log.info({ security: payload }, "security_event");
@@ -46,101 +62,6 @@ export async function registerAdminDataRoutes(
 
   app.post("/admin/data/delete", async (request, reply) => {
     const principal = parseAuthorization(request);
-=======
-import { FastifyPluginAsync, FastifyRequest } from "fastify";
-import { z } from "zod";
-import {
-  subjectDataExportRequestSchema,
-  subjectDataExportResponseSchema,
-} from "../schemas/admin.data";
-
-const principalSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  role: z.enum(["admin", "user"]),
-  email: z.string().email(),
-});
-
-type Principal = z.infer<typeof principalSchema>;
-
-type DbClient = {
-  user: {
-    findFirst: (args: {
-      where: { email: string; orgId: string };
-      select: {
-        id: true;
-        email: true;
-        createdAt: true;
-        org: { select: { id: true; name: true } };
-      };
-    }) => Promise<
-      | {
-          id: string;
-          email: string;
-          createdAt: Date;
-          org: { id: string; name: string };
-        }
-      | null
-    >;
-  };
-  bankLine: {
-    count: (args: { where: { orgId: string } }) => Promise<number>;
-  };
-  accessLog?: {
-    create: (args: {
-      data: {
-        event: string;
-        orgId: string;
-        principalId: string;
-        subjectEmail: string;
-      };
-    }) => Promise<unknown>;
-  };
-};
-
-type SecLogFn = (payload: {
-  event: string;
-  orgId: string;
-  principal: string;
-  subjectEmail: string;
-}) => void;
-
-const parsePrincipal = (req: FastifyRequest): Principal | null => {
-  const header = req.headers.authorization;
-  if (!header) return null;
-  const match = /^Bearer\s+(.+)$/i.exec(header);
-  if (!match) return null;
-  try {
-    const decoded = Buffer.from(match[1], "base64url").toString("utf8");
-    const parsed = JSON.parse(decoded);
-    return principalSchema.parse(parsed);
-  } catch {
-    return null;
-  }
-};
-
-const adminDataRoutes: FastifyPluginAsync = async (app) => {
-  const db: DbClient | undefined = (app as any).db;
-  if (!db) {
-    throw new Error("database client not registered");
-  }
-
-  const log: SecLogFn =
-    (app as any).secLog ??
-    ((entry) => {
-      app.log.info({ event: entry.event, ...entry }, "security_event");
-    });
-
-  app.post("/admin/data/export", async (req, reply) => {
-    const bodyResult = subjectDataExportRequestSchema.safeParse(req.body);
-    if (!bodyResult.success) {
-      return reply.code(400).send({ error: "invalid_request" });
-    }
-
-    const body = bodyResult.data;
-
-    const principal = parsePrincipal(req);
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
     if (!principal) {
       return reply.code(401).send({ error: "unauthorized" });
     }
@@ -149,7 +70,6 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
       return reply.code(403).send({ error: "forbidden" });
     }
 
-<<<<<<< HEAD
     const parsed = adminDataDeleteRequestSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: "invalid_request" });
@@ -157,13 +77,10 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
 
     const body = parsed.data;
 
-=======
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
     if (principal.orgId !== body.orgId) {
       return reply.code(403).send({ error: "forbidden" });
     }
 
-<<<<<<< HEAD
     const subject = await prisma.user.findFirst({
       where: { orgId: body.orgId, email: body.email },
     });
@@ -216,10 +133,97 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.code(202).send(response);
   });
+
+  app.post("/admin/data/export", async (request, reply) => {
+    const principal = parseAuthorization(request);
+    if (!principal) {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    if (principal.role !== "admin") {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const bodyResult = subjectDataExportRequestSchema.safeParse(request.body);
+    if (!bodyResult.success) {
+      return reply.code(400).send({ error: "invalid_request" });
+    }
+
+    const body = bodyResult.data;
+
+    if (principal.orgId !== body.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const userRecord = await prisma.user.findFirst({
+      where: { email: body.email, orgId: body.orgId },
+      select: {
+        id: true,
+        email: true,
+        createdAt: true,
+        org: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!userRecord) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const bankLinesCount = await prisma.bankLine.count({
+      where: { orgId: body.orgId },
+    });
+
+    const exportedAt = new Date().toISOString();
+
+    if (prisma.accessLog?.create) {
+      await prisma.accessLog.create({
+        data: {
+          event: "data_export",
+          orgId: body.orgId,
+          principalId: principal.id,
+          subjectEmail: body.email,
+        },
+      });
+    }
+
+    await securityLogger({
+      event: "data_export",
+      orgId: body.orgId,
+      principal: principal.id,
+      subjectEmail: body.email,
+    });
+
+    const responsePayload = subjectDataExportResponseSchema.parse({
+      org: {
+        id: userRecord.org.id,
+        name: userRecord.org.name,
+      },
+      user: {
+        id: userRecord.id,
+        email: userRecord.email,
+        createdAt: userRecord.createdAt.toISOString(),
+      },
+      relationships: {
+        bankLinesCount,
+      },
+      exportedAt,
+    });
+
+    return reply.send(responsePayload satisfies SubjectDataExportResponse);
+  });
 }
 
+const principalSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  role: z.enum(["admin", "user"]),
+  email: z.string().email().optional(),
+});
+
 function parseAuthorization(request: FastifyRequest): Principal | null {
-  const header = request.headers["authorization"] ?? request.headers["Authorization" as keyof typeof request.headers];
+  const header =
+    request.headers["authorization"] ??
+    request.headers["Authorization" as keyof typeof request.headers];
   if (!header || typeof header !== "string") {
     return null;
   }
@@ -230,21 +234,55 @@ function parseAuthorization(request: FastifyRequest): Principal | null {
   }
 
   const token = match[1];
-  const [role, principalId, orgId] = token.split(":");
-  if (!role || !principalId || !orgId) {
+
+  const decoded = tryDecodePrincipal(token);
+  if (!decoded) {
     return null;
   }
 
-  return {
-    id: principalId,
-    role,
-    orgId,
-    token,
-  };
+  return { ...decoded, token } satisfies Principal;
+}
+
+function tryDecodePrincipal(token: string): Omit<Principal, "token"> | null {
+  const jsonDecoded = tryParseJsonPrincipal(token);
+  if (jsonDecoded) {
+    return jsonDecoded;
+  }
+
+  const colonDecoded = tryParseColonPrincipal(token);
+  if (colonDecoded) {
+    return colonDecoded;
+  }
+
+  return null;
+}
+
+function tryParseJsonPrincipal(token: string): Omit<Principal, "token"> | null {
+  try {
+    const decoded = Buffer.from(token, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded);
+    const validated = principalSchema.parse(parsed);
+    return validated;
+  } catch {
+    return null;
+  }
+}
+
+function tryParseColonPrincipal(token: string): Omit<Principal, "token"> | null {
+  const [role, id, orgId] = token.split(":");
+  if (!role || !id || !orgId) {
+    return null;
+  }
+
+  try {
+    return principalSchema.parse({ role, id, orgId });
+  } catch {
+    return null;
+  }
 }
 
 async function detectForeignKeyRisk(
-  prisma: PrismaClientLike,
+  prisma: Pick<PrismaClientLike, "bankLine">,
   userId: string,
   email: string,
   orgId: string
@@ -287,68 +325,16 @@ async function getDefaultPrisma(): Promise<PrismaClientLike> {
   return cachedDefaultPrisma;
 }
 
-export type { AdminDataDeleteRequest, AdminDataDeleteResponse };
-=======
-    const userRecord = await db.user.findFirst({
-      where: { email: body.email, orgId: body.orgId },
-      select: {
-        id: true,
-        email: true,
-        createdAt: true,
-        org: { select: { id: true, name: true } },
-      },
-    });
+export type {
+  AdminDataDeleteRequest,
+  AdminDataDeleteResponse,
+  SubjectDataExportRequest,
+  SubjectDataExportResponse,
+  SecurityLogPayload,
+};
 
-    if (!userRecord) {
-      return reply.code(404).send({ error: "not_found" });
-    }
-
-    const bankLinesCount = await db.bankLine.count({
-      where: { orgId: body.orgId },
-    });
-
-    const exportedAt = new Date().toISOString();
-
-    if (db.accessLog?.create) {
-      await db.accessLog.create({
-        data: {
-          event: "data_export",
-          orgId: body.orgId,
-          principalId: principal.id,
-          subjectEmail: body.email,
-        },
-      });
-    }
-
-    log({
-      event: "data_export",
-      orgId: body.orgId,
-      principal: principal.id,
-      subjectEmail: body.email,
-    });
-
-    const responsePayload = {
-      org: {
-        id: userRecord.org.id,
-        name: userRecord.org.name,
-      },
-      user: {
-        id: userRecord.id,
-        email: userRecord.email,
-        createdAt: userRecord.createdAt.toISOString(),
-      },
-      relationships: {
-        bankLinesCount,
-      },
-      exportedAt,
-    };
-
-    const validated = subjectDataExportResponseSchema.parse(responsePayload);
-
-    return reply.send(validated);
-  });
+export const adminDataRoutes: FastifyPluginAsync = async (app) => {
+  await registerAdminDataRoutes(app);
 };
 
 export default adminDataRoutes;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-

--- a/services/api-gateway/src/schemas/admin.data.ts
+++ b/services/api-gateway/src/schemas/admin.data.ts
@@ -1,6 +1,5 @@
-﻿import { z } from "zod";
+import { z } from "zod";
 
-<<<<<<< HEAD
 export const adminDataDeleteRequestSchema = z.object({
   orgId: z.string().min(1, "orgId is required"),
   email: z.string().email("email must be valid"),
@@ -17,9 +16,6 @@ export const adminDataDeleteResponseSchema = z.object({
     }),
 });
 
-export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
-export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
-=======
 export const subjectDataExportRequestSchema = z.object({
   orgId: z.string().min(1),
   email: z.string().email(),
@@ -33,7 +29,11 @@ const orgSchema = z.object({
 const userSchema = z.object({
   id: z.string(),
   email: z.string().email(),
-  createdAt: z.string(),
+  createdAt: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), {
+      message: "createdAt must be ISO string",
+    }),
 });
 
 const relationshipsSchema = z.object({
@@ -44,15 +44,14 @@ export const subjectDataExportResponseSchema = z.object({
   org: orgSchema,
   user: userSchema,
   relationships: relationshipsSchema,
-  exportedAt: z.string(),
+  exportedAt: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), {
+      message: "exportedAt must be ISO string",
+    }),
 });
 
-export type SubjectDataExportRequest = z.infer<
-  typeof subjectDataExportRequestSchema
->;
-
-export type SubjectDataExportResponse = z.infer<
-  typeof subjectDataExportResponseSchema
->;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-
+export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
+export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
+export type SubjectDataExportRequest = z.infer<typeof subjectDataExportRequestSchema>;
+export type SubjectDataExportResponse = z.infer<typeof subjectDataExportResponseSchema>;

--- a/services/api-gateway/test/admin.data.delete.spec.ts
+++ b/services/api-gateway/test/admin.data.delete.spec.ts
@@ -90,7 +90,7 @@ describe("POST /admin/data/delete", () => {
       url: "/admin/data/delete",
       payload: defaultPayload,
       headers: {
-        authorization: buildToken("member", defaultPayload.orgId),
+        authorization: buildToken("user", defaultPayload.orgId),
       },
     });
 

--- a/services/api-gateway/test/all.test.js
+++ b/services/api-gateway/test/all.test.js
@@ -1,0 +1,2 @@
+import "./admin.data.delete.spec.ts";
+import "./admin.data.export.spec.ts";


### PR DESCRIPTION
## Summary
- unify the admin data delete and export endpoints behind a shared route registration with consistent principal parsing and logging
- align the admin data request/response schemas with the merged route behaviour
- refresh the admin data tests and add an aggregate test entry point so the workspace test command executes them

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f795a6248883278225bcf7cfeae3a2