### PR TITLE
Add Vitest smoke tests for webapp pages

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -8,7 +8,8 @@
                     "build":  "vite build",
                     "preview":  "vite preview",
                     "test":  "playwright test",
-                    "test:axe":  "playwright test tests/axe.spec.ts"
+                    "test:axe":  "playwright test tests/axe.spec.ts",
+                    "test:unit":  "vitest"
                 },
     "dependencies":  {
                          "react":  "^18.3.1",
@@ -18,10 +19,14 @@
     "devDependencies":  {
                             "@axe-core/playwright":  "^4.9.0",
                             "@playwright/test":  "^1.47.1",
+                            "@testing-library/jest-dom":  "^6.5.0",
+                            "@testing-library/react":  "^16.0.0",
                             "@types/react":  "^18.3.3",
                             "@types/react-dom":  "^18.3.1",
                             "@vitejs/plugin-react":  "^4.3.1",
+                            "jsdom":  "^24.1.3",
                             "typescript":  "^5.9.3",
-                            "vite":  "^5.4.1"
+                            "vite":  "^5.4.1",
+                            "vitest":  "^2.1.1"
                         }
 }

--- a/webapp/src/pages/__tests__/BankLines.test.tsx
+++ b/webapp/src/pages/__tests__/BankLines.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import BankLinesPage from '../BankLines';
+
+describe('BankLinesPage', () => {
+  it('renders the portfolio visibility heading and lender labels', () => {
+    render(<BankLinesPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /bank line visibility/i })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: /export exposure report/i })
+    ).toBeInTheDocument();
+
+    const table = screen.getByRole('table', {
+      name: /breakdown of bank line utilization and statuses/i
+    });
+
+    expect(within(table).getByRole('columnheader', { name: /lender/i })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: /limit/i })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: /status/i })).toBeInTheDocument();
+    expect(within(table).getByRole('columnheader', { name: /notes/i })).toBeInTheDocument();
+  });
+});

--- a/webapp/src/pages/__tests__/Home.test.tsx
+++ b/webapp/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import HomePage from '../Home';
+
+describe('HomePage', () => {
+  it('renders the primary heading and key workflow labels', () => {
+    render(<HomePage />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /portfolio pulse/i })
+    ).toBeInTheDocument();
+
+    const metricsSection = screen.getByLabelText(/key metrics/i);
+    expect(
+      within(metricsSection).getByRole('heading', { level: 2, name: /active mandates/i })
+    ).toBeInTheDocument();
+    expect(
+      within(metricsSection).getByRole('heading', {
+        level: 2,
+        name: /total committed capital/i
+      })
+    ).toBeInTheDocument();
+
+    const activitySection = screen.getByLabelText(/latest activity/i);
+    expect(
+      within(activitySection).getByRole('heading', { level: 2, name: /workflow alerts/i })
+    ).toBeInTheDocument();
+    expect(
+      within(activitySection).getByText(
+        /curated tasks across deal teams and syndicate partners/i
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/webapp/src/test/setup.ts
+++ b/webapp/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/webapp/src/utils/format.test.ts
+++ b/webapp/src/utils/format.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { fmtCurrency } from './format';
+
+describe('fmtCurrency', () => {
+  it('formats whole numbers as Australian dollars without cents', () => {
+    expect(fmtCurrency(202000)).toBe('$202,000');
+  });
+});

--- a/webapp/src/utils/format.ts
+++ b/webapp/src/utils/format.ts
@@ -1,0 +1,24 @@
+const DEFAULT_LOCALE = 'en-AU';
+
+const DEFAULT_CURRENCY_OPTIONS: Intl.NumberFormatOptions = {
+  style: 'currency',
+  currency: 'AUD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0
+};
+
+/**
+ * Format a numeric value as an Australian dollar currency string.
+ */
+export function fmtCurrency(
+  value: number,
+  options: Intl.NumberFormatOptions = {},
+  locale: string = DEFAULT_LOCALE
+): string {
+  const formatter = new Intl.NumberFormat(locale, {
+    ...DEFAULT_CURRENCY_OPTIONS,
+    ...options
+  });
+
+  return formatter.format(value);
+}

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "tests"]
 }

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -6,5 +6,10 @@ export default defineConfig({
   server: {
     port: 4173,
     host: '0.0.0.0'
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    css: true
   }
 });


### PR DESCRIPTION
## Summary
- configure Vitest with React Testing Library and jest-dom for the webapp
- add smoke tests that assert the key headings and labels render on the Home and Bank Lines pages
- introduce a currency formatter helper with a unit test covering the $202,000 case

## Testing
- `pnpm --filter @apgms/webapp test:unit` *(fails: vitest executable not installed because the npm registry responds with 403 during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68f78917b6d883279aca40ed6e061579