### PR TITLE
feat(webapp): add shared formatting utilities

### DIFF
--- a/webapp/src/lib/format.ts
+++ b/webapp/src/lib/format.ts
@@ -1,0 +1,10 @@
+export const fmtCurrency = (n: number) =>
+  n.toLocaleString('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: 0
+  });
+
+export const fmtPct = (p: number, digits = 1) => `${p.toFixed(digits)}%`;
+
+export const trendColor = (p: number) => (p >= 0 ? 'text-success' : 'text-danger');

--- a/webapp/src/pages/BankLines.tsx
+++ b/webapp/src/pages/BankLines.tsx
@@ -1,11 +1,12 @@
-﻿import './BankLines.css';
+import './BankLines.css';
+import { fmtCurrency, fmtPct } from '../lib/format';
 
 type LineStatus = 'Active' | 'Pending' | 'Monitoring';
 
 type BankLine = {
   bank: string;
-  limit: string;
-  utilization: string;
+  limit: number;
+  utilization: number;
   status: LineStatus;
   updated: string;
   notes: string;
@@ -14,24 +15,24 @@ type BankLine = {
 const bankLines: BankLine[] = [
   {
     bank: 'Commonwealth Bank',
-    limit: '$1.2B',
-    utilization: '64%',
+    limit: 1_200_000_000,
+    utilization: 64,
     status: 'Active',
     updated: 'Today 10:24',
     notes: 'Term sheet expansion approved for Helios storage facility.'
   },
   {
     bank: 'Northwind Credit Union',
-    limit: '$820M',
-    utilization: '71%',
+    limit: 820_000_000,
+    utilization: 71,
     status: 'Monitoring',
     updated: 'Yesterday',
     notes: 'Utilization trending upward ahead of portfolio rebalance.'
   },
   {
     bank: 'First Harbor Partners',
-    limit: '$640M',
-    utilization: '48%',
+    limit: 640_000_000,
+    utilization: 48,
     status: 'Pending',
     updated: '2 days ago',
     notes: 'Awaiting revised covenants from legal after counterparty feedback.'
@@ -77,14 +78,14 @@ export default function BankLinesPage() {
             {bankLines.map((line) => (
               <tr key={line.bank}>
                 <th scope="row">{line.bank}</th>
-                <td>{line.limit}</td>
+                <td>{fmtCurrency(line.limit)}</td>
                 <td>
                   <div className="bank-lines__utilization">
-                    <span>{line.utilization}</span>
+                    <span>{fmtPct(line.utilization, 0)}</span>
                     <div className="bank-lines__utilization-track" aria-hidden="true">
                       <div
                         className="bank-lines__utilization-fill"
-                        style={{ width: line.utilization }}
+                        style={{ width: `${line.utilization}%` }}
                       />
                     </div>
                   </div>

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,23 +1,50 @@
-﻿import './Home.css';
+import './Home.css';
+import { fmtCurrency, fmtPct, trendColor } from '../lib/format';
 
-const metrics = [
+type Metric = {
+  title: string;
+  value: number;
+  description: string;
+  valueFormatter?: (value: number) => string;
+  change?: {
+    delta: number;
+    suffix?: string;
+    formatter?: (value: number) => string;
+  };
+};
+
+const metrics: Metric[] = [
   {
     title: 'Active mandates',
-    value: '24',
-    change: '+3.4% vs last week',
+    value: 24,
+    change: {
+      delta: 3.4,
+      suffix: 'vs last week',
+      formatter: (value) => fmtPct(value, 1)
+    },
     description:
       'Structured credit and private equity deals currently tracked in the Pro+ workspace.'
   },
   {
     title: 'Total committed capital',
-    value: '$4.8B',
-    change: '+$180M new commitments',
+    value: 4_800_000_000,
+    valueFormatter: fmtCurrency,
+    change: {
+      delta: 180_000_000,
+      suffix: 'new commitments',
+      formatter: fmtCurrency
+    },
     description: 'Aggregate bank and fund lines allocated across open portfolios.'
   },
   {
     title: 'Average utilization',
-    value: '67%',
-    change: '-5.3% risk exposure',
+    value: 67,
+    valueFormatter: (value) => fmtPct(value, 0),
+    change: {
+      delta: -5.3,
+      suffix: 'risk exposure',
+      formatter: fmtPct
+    },
     description: 'Weighted utilization across all active bank lines for the current quarter.'
   }
 ];
@@ -52,16 +79,33 @@ export default function HomePage() {
       </header>
 
       <section aria-label="Key metrics" className="metric-grid">
-        {metrics.map((metric) => (
-          <article className="metric-card" key={metric.title}>
-            <header className="metric-card__header">
-              <h2>{metric.title}</h2>
-              <span className="metric-card__change">{metric.change}</span>
-            </header>
-            <p className="metric-card__value">{metric.value}</p>
-            <p className="metric-card__description">{metric.description}</p>
-          </article>
-        ))}
+        {metrics.map((metric) => {
+          const valueFormatter =
+            metric.valueFormatter ?? ((value: number) => value.toLocaleString('en-AU'));
+          const change = metric.change;
+          const changeContent = change
+            ? `${change.delta >= 0 ? '+' : '−'}${
+                change.formatter
+                  ? change.formatter(Math.abs(change.delta))
+                  : Math.abs(change.delta).toLocaleString('en-AU')
+              }${change.suffix ? ` ${change.suffix}` : ''}`
+            : null;
+
+          return (
+            <article className="metric-card" key={metric.title}>
+              <header className="metric-card__header">
+                <h2>{metric.title}</h2>
+                {change && changeContent ? (
+                  <span className={`metric-card__change ${trendColor(change.delta)}`}>
+                    {changeContent}
+                  </span>
+                ) : null}
+              </header>
+              <p className="metric-card__value">{valueFormatter(metric.value)}</p>
+              <p className="metric-card__description">{metric.description}</p>
+            </article>
+          );
+        })}
       </section>
 
       <section aria-label="Latest activity" className="activity">

--- a/webapp/src/styles/global.css
+++ b/webapp/src/styles/global.css
@@ -16,6 +16,14 @@ body {
   color: var(--color-text);
 }
 
+.text-success {
+  color: var(--color-success) !important;
+}
+
+.text-danger {
+  color: var(--color-danger) !important;
+}
+
 h1,
  h2,
  h3,


### PR DESCRIPTION
## Summary
- add shared helpers for consistent currency, percentage, and trend styling in the web app
- adopt the helpers across the Home metrics and BankLines table displays
- expose success and danger utility classes to support trend-aware styling

## Testing
- pnpm --filter @apgms/webapp test -- --reporter=line *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68f788f543008327b1927d256a5c2264