### PR TITLE
Fix CI workflow directories and pnpm steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,63 +2,83 @@ name: CI
 
 on: [push, pull_request]
 
-defaults:
-  run:
-    working-directory: apgms
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
-          cache-dependency-path: apgms/pnpm-lock.yaml
-      - run: pnpm install
-      - run: pnpm exec playwright install --with-deps
-      - run: pnpm -r build
-      - run: pnpm -r test
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Build packages
+        run: pnpm -r build
+      - name: Run tests
+        run: pnpm -r test
 
   axe:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
-          cache-dependency-path: apgms/pnpm-lock.yaml
-      - run: pnpm install
-      - run: pnpm exec playwright install --with-deps
-      - run: pnpm --filter @apgms/webapp test:axe
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Build packages
+        run: pnpm -r build
+      - name: Run axe tests
+        run: pnpm --filter @apgms/webapp test:axe
 
   lighthouse:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
-          cache-dependency-path: apgms/pnpm-lock.yaml
-      - run: pnpm install
-      - run: pnpm --filter @apgms/webapp build
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Build packages
+        run: pnpm -r build
+      - name: Run Playwright tests
+        run: pnpm --filter @apgms/webapp test
       - name: Lighthouse CI
         uses: treosh/lighthouse-ci-action@v10
         with:
-          configPath: ./apgms/lighthouserc.json
+          configPath: ./lighthouserc.json
           runs: 1
           uploadArtifacts: true


### PR DESCRIPTION
## Summary
- remove the repository-level working directory override so workflow steps run from the checkout root
- add corepack, frozen pnpm install, recursive build, and test steps for each job together with Playwright browser installation
- point Lighthouse configuration to the correct path after running the shared build and Playwright tests

## Testing
- not run (act binary download blocked in container)

------
https://chatgpt.com/codex/tasks/task_e_68f795ab2e4c83279c496fbca0f490b9