### PR TITLE
feat(webapp): add status chip component

### DIFF
--- a/webapp/src/components/StatusChip.tsx
+++ b/webapp/src/components/StatusChip.tsx
@@ -1,0 +1,61 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+import { cva } from '../lib/cva';
+import { cn } from '../lib/utils';
+
+const variantStyles = {
+  active: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20',
+  secure: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20',
+  monitor: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20',
+  warning: 'bg-amber-50 text-amber-800 ring-amber-600/20',
+  info: 'bg-blue-50 text-blue-700 ring-blue-600/20',
+  pending: 'bg-amber-50 text-amber-800 ring-amber-600/20',
+  resolved: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20',
+  inProgress: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20'
+} as const;
+
+const dotStyles = {
+  active: 'bg-emerald-500',
+  secure: 'bg-emerald-500',
+  monitor: 'bg-indigo-500',
+  warning: 'bg-amber-500',
+  info: 'bg-blue-500',
+  pending: 'bg-amber-500',
+  resolved: 'bg-emerald-500',
+  inProgress: 'bg-indigo-500'
+} as const;
+
+export type StatusChipVariant = keyof typeof variantStyles;
+
+const statusChipVariants = cva(
+  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium leading-5 ring-1 ring-inset text-nowrap',
+  {
+    variants: {
+      variant: variantStyles
+    },
+    defaultVariants: {
+      variant: 'info'
+    }
+  }
+);
+
+type StatusChipBaseProps = ComponentPropsWithoutRef<'span'>;
+
+export interface StatusChipProps extends StatusChipBaseProps {
+  variant?: StatusChipVariant;
+  children: ReactNode;
+}
+
+export default function StatusChip({
+  children,
+  className,
+  variant = 'info',
+  ...props
+}: StatusChipProps) {
+  return (
+    <span className={cn(statusChipVariants({ variant }), className)} {...props}>
+      <span aria-hidden className={cn('h-2 w-2 rounded-full', dotStyles[variant])} />
+      <span>{children}</span>
+    </span>
+  );
+}

--- a/webapp/src/lib/cva.ts
+++ b/webapp/src/lib/cva.ts
@@ -1,0 +1,36 @@
+type VariantMap = Record<string, Record<string, string | undefined>>;
+
+type DefaultVariants<V extends VariantMap> = {
+  [K in keyof V]?: keyof V[K];
+};
+
+type VariantSelection<V extends VariantMap> = {
+  [K in keyof V]?: keyof V[K];
+};
+
+type CvaOptions<V extends VariantMap> = {
+  variants?: V;
+  defaultVariants?: DefaultVariants<V>;
+};
+
+export function cva<V extends VariantMap>(
+  base: string,
+  options: CvaOptions<V> = {}
+): (selection?: VariantSelection<V>) => string {
+  const { variants = {} as V, defaultVariants = {} as DefaultVariants<V> } = options;
+
+  return (selection: VariantSelection<V> = {}) => {
+    const classes: Array<string> = [base];
+    const resolved = { ...defaultVariants, ...selection } as VariantSelection<V>;
+
+    (Object.keys(variants) as Array<keyof V>).forEach((variantKey) => {
+      const variantDefinition = variants[variantKey];
+      const value = resolved[variantKey];
+      if (value && variantDefinition[value]) {
+        classes.push(variantDefinition[value] as string);
+      }
+    });
+
+    return classes.filter(Boolean).join(' ');
+  };
+}

--- a/webapp/src/lib/utils.ts
+++ b/webapp/src/lib/utils.ts
@@ -1,0 +1,5 @@
+type ClassValue = string | number | null | undefined | false;
+
+export function cn(...inputs: ClassValue[]): string {
+  return inputs.filter(Boolean).join(' ');
+}

--- a/webapp/src/pages/BankLines.css
+++ b/webapp/src/pages/BankLines.css
@@ -97,40 +97,17 @@ tbody tr + tr {
   background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-success) 100%);
 }
 
-.status-badge {
-  display: inline-flex;
+.bank-lines__status {
+  display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--spacing-3xs);
-  padding: var(--spacing-2xs) var(--spacing-sm);
-  border-radius: var(--radius-md);
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
-.status-badge__label {
-  font-size: var(--font-size-xs);
-}
-
-.status-badge__hint {
+.bank-lines__status-hint {
   font-size: var(--font-size-xxs, 0.65rem);
-  opacity: 0.85;
-}
-
-.status-badge--active {
-  background-color: rgba(10, 125, 87, 0.16);
-  color: var(--color-success);
-}
-
-.status-badge--pending {
-  background-color: rgba(185, 115, 24, 0.18);
-  color: var(--color-warning);
-}
-
-.status-badge--monitoring {
-  background-color: var(--color-primary-soft);
-  color: var(--color-primary);
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
 }
 
 .sr-only {

--- a/webapp/src/pages/BankLines.tsx
+++ b/webapp/src/pages/BankLines.tsx
@@ -1,6 +1,8 @@
-﻿import './BankLines.css';
+import StatusChip, { type StatusChipVariant } from '../components/StatusChip';
 
-type LineStatus = 'Active' | 'Pending' | 'Monitoring';
+import './BankLines.css';
+
+type LineStatus = 'Active' | 'Pending' | 'Monitor';
 
 type BankLine = {
   bank: string;
@@ -24,7 +26,7 @@ const bankLines: BankLine[] = [
     bank: 'Northwind Credit Union',
     limit: '$820M',
     utilization: '71%',
-    status: 'Monitoring',
+    status: 'Monitor',
     updated: 'Yesterday',
     notes: 'Utilization trending upward ahead of portfolio rebalance.'
   },
@@ -41,7 +43,13 @@ const bankLines: BankLine[] = [
 const statusLabels: Record<LineStatus, string> = {
   Active: 'Operational',
   Pending: 'Requires approval',
-  Monitoring: 'Watch closely'
+  Monitor: 'Watch closely'
+};
+
+const statusVariants: Record<LineStatus, StatusChipVariant> = {
+  Active: 'active',
+  Pending: 'pending',
+  Monitor: 'monitor'
 };
 
 export default function BankLinesPage() {
@@ -90,10 +98,10 @@ export default function BankLinesPage() {
                   </div>
                 </td>
                 <td>
-                  <span className={`status-badge status-badge--${line.status.toLowerCase()}`}>
-                    <span className="status-badge__label">{line.status}</span>
-                    <span className="status-badge__hint">{statusLabels[line.status]}</span>
-                  </span>
+                  <div className="bank-lines__status">
+                    <StatusChip variant={statusVariants[line.status]}>{line.status}</StatusChip>
+                    <span className="bank-lines__status-hint">{statusLabels[line.status]}</span>
+                  </div>
                 </td>
                 <td>{line.updated}</td>
                 <td>{line.notes}</td>


### PR DESCRIPTION
## Summary
- add a reusable StatusChip component with variant-driven Tailwind classes and dot accents
- introduce lightweight cva/cn helpers to compose pill styles without external dependencies
- switch the bank lines status column to the new chip while keeping supporting copy aligned

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f788e3ebb083278520869216eeec4f