### PR TITLE
feat(webapp): add compliance monitoring route

### DIFF
--- a/apps/webapp/src/pages/compliance.tsx
+++ b/apps/webapp/src/pages/compliance.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../../webapp/src/pages/Compliance';

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import HomePage from './pages/Home';
 import BankLinesPage from './pages/BankLines';
+import CompliancePage from './pages/Compliance';
 import './App.css';
 
 type Theme = 'light' | 'dark';
@@ -47,6 +48,9 @@ export default function App() {
           <NavLink className="app__nav-link" to="/bank-lines">
             Bank lines
           </NavLink>
+          <NavLink className="app__nav-link" to="/compliance">
+            Compliance
+          </NavLink>
         </nav>
         <button
           type="button"
@@ -61,6 +65,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/bank-lines" element={<BankLinesPage />} />
+          <Route path="/compliance" element={<CompliancePage />} />
         </Routes>
       </main>
       <footer className="app__footer">

--- a/webapp/src/pages/Compliance.css
+++ b/webapp/src/pages/Compliance.css
@@ -1,0 +1,224 @@
+.compliance {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xl);
+  padding-top: var(--spacing-2xl);
+}
+
+.compliance__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-xl);
+}
+
+.compliance__intro {
+  display: grid;
+  gap: var(--spacing-sm);
+  max-width: 48rem;
+}
+
+.compliance__intro h1 {
+  font-size: var(--font-size-2xl);
+  letter-spacing: -0.03em;
+}
+
+.compliance__intro p {
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
+}
+
+.compliance__export {
+  align-self: flex-start;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-strong);
+  background-color: var(--color-surface);
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.compliance__export:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--color-primary);
+}
+
+.compliance__export:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+.compliance__tabs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.compliance__tablist {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.compliance__tab {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background-color: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 180ms ease, color 180ms ease, border-color 180ms ease;
+}
+
+.compliance__tab[aria-selected='true'] {
+  color: var(--color-primary-contrast);
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.compliance__tab:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.compliance__panel {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.alert-grid {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.alert-card {
+  border-radius: var(--radius-lg);
+  border: 2px solid var(--color-border);
+  padding: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-md);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.7));
+}
+
+.alert-card--warning {
+  border-color: rgba(185, 115, 24, 0.55);
+  box-shadow: 0 12px 30px rgba(185, 115, 24, 0.18);
+}
+
+.alert-card--info {
+  border-color: rgba(0, 90, 214, 0.55);
+  box-shadow: 0 12px 30px rgba(0, 90, 214, 0.18);
+}
+
+.alert-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  align-items: flex-start;
+}
+
+.alert-card__content {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.alert-card__title {
+  font-size: var(--font-size-lg);
+  letter-spacing: -0.01em;
+}
+
+.alert-card__description {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--font-lineheight-relaxed);
+}
+
+.alert-card__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3xs);
+  padding: var(--spacing-3xs) var(--spacing-sm);
+  border-radius: var(--radius-pill);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.alert-card--warning .alert-card__pill {
+  background-color: rgba(185, 115, 24, 0.14);
+  color: var(--color-warning);
+}
+
+.alert-card--info .alert-card__pill {
+  background-color: rgba(0, 90, 214, 0.14);
+  color: var(--color-primary);
+}
+
+.alert-card__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+  align-items: center;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.alert-card__timestamp {
+  font-weight: var(--font-weight-medium);
+}
+
+.alert-card__action {
+  margin-left: auto;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-pill);
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.alert-card__action:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.alert-card__action:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.compliance__placeholder {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 780px) {
+  .compliance__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .alert-card__header,
+  .alert-card__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .alert-card__action {
+    margin-left: 0;
+  }
+}

--- a/webapp/src/pages/Compliance.tsx
+++ b/webapp/src/pages/Compliance.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import './Compliance.css';
+
+type TabKey = 'Alerts' | 'Payment Plans' | 'Audit Trail' | 'Documents';
+
+type AlertTone = 'warning' | 'info';
+
+type Alert = {
+  id: string;
+  title: string;
+  description: string;
+  tone: AlertTone;
+  badge: string;
+  timestamp: string;
+  actionLabel?: string;
+};
+
+const alerts: Alert[] = [
+  {
+    id: 'paygw-variance',
+    title: 'PAYGW Variance Detected',
+    description: 'Secured funds are 7.7% below liability. Review payroll calculations.',
+    tone: 'warning',
+    badge: 'Warning',
+    timestamp: '2 hours ago',
+    actionLabel: 'Investigate →'
+  },
+  {
+    id: 'gst-reconciliation',
+    title: 'GST Reconciliation Available',
+    description: 'Latest reconciliation package is ready for review.',
+    tone: 'info',
+    badge: 'Info',
+    timestamp: '4 hours ago'
+  }
+];
+
+const placeholderCopy: Record<Exclude<TabKey, 'Alerts'>, string> = {
+  'Payment Plans': 'No payment plan exceptions detected. Upcoming schedules will surface here.',
+  'Audit Trail': 'Audit logs will populate with reviewer notes and approval checkpoints.',
+  Documents: 'Centralized policy documents and attestations will be listed here for download.'
+};
+
+export default function CompliancePage() {
+  const [activeTab, setActiveTab] = useState<TabKey>('Alerts');
+
+  return (
+    <div className="compliance">
+      <header className="compliance__header">
+        <div className="compliance__intro">
+          <h1>Compliance control center</h1>
+          <p>Monitor alerts, payment plans, audit trail, and compliance documentation.</p>
+        </div>
+        <button type="button" className="compliance__export">
+          Export Reports
+        </button>
+      </header>
+
+      <section className="compliance__tabs" aria-labelledby="compliance-tabs-heading">
+        <h2 id="compliance-tabs-heading" className="sr-only">
+          Compliance workspace navigation
+        </h2>
+        <div className="compliance__tablist" role="tablist" aria-label="Compliance sections">
+          {(['Alerts', 'Payment Plans', 'Audit Trail', 'Documents'] as TabKey[]).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              role="tab"
+              className="compliance__tab"
+              aria-selected={activeTab === tab}
+              aria-controls={`compliance-panel-${tab.toLowerCase().replace(/\s+/g, '-')}`}
+              id={`compliance-tab-${tab.toLowerCase().replace(/\s+/g, '-')}`}
+              onClick={() => setActiveTab(tab)}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        <div
+          role="tabpanel"
+          id={`compliance-panel-${activeTab.toLowerCase().replace(/\s+/g, '-')}`}
+          aria-labelledby={`compliance-tab-${activeTab.toLowerCase().replace(/\s+/g, '-')}`}
+          className="compliance__panel"
+        >
+          {activeTab === 'Alerts' ? (
+            <div className="alert-grid">
+              {alerts.map((alert) => (
+                <article
+                  key={alert.id}
+                  className={`alert-card alert-card--${alert.tone}`}
+                  aria-label={`${alert.title} alert`}
+                >
+                  <header className="alert-card__header">
+                    <div className="alert-card__content">
+                      <h3 className="alert-card__title">{alert.title}</h3>
+                      <p className="alert-card__description">{alert.description}</p>
+                    </div>
+                    <span className="alert-card__pill">{alert.badge}</span>
+                  </header>
+                  <footer className="alert-card__footer">
+                    <span className="alert-card__timestamp">{alert.timestamp}</span>
+                    {alert.actionLabel ? (
+                      <button type="button" className="alert-card__action">
+                        {alert.actionLabel}
+                      </button>
+                    ) : null}
+                  </footer>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="compliance__placeholder">{placeholderCopy[activeTab]}</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a compliance control center page with tab navigation and alert cards
- style the new compliance view and expose an export reports control
- register the compliance route in the main webapp navigation

## Testing
- pnpm --filter webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f788c7b9e88327bcaf1acef4fb7989