### PR TITLE
Add overview dashboard route

### DIFF
--- a/apps/webapp/src/components/AppShell.module.css
+++ b/apps/webapp/src/components/AppShell.module.css
@@ -1,0 +1,49 @@
+.shell {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.05), transparent 55%),
+    linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+  padding: 3.5rem 1.5rem 4rem;
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.title {
+  font-size: clamp(1.75rem, 2.5vw, 2.5rem);
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.5rem;
+}
+
+.description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #334155;
+  max-width: 45ch;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}

--- a/apps/webapp/src/components/AppShell.tsx
+++ b/apps/webapp/src/components/AppShell.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import styles from './AppShell.module.css';
+
+type AppShellProps = PropsWithChildren<{
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}>;
+
+export function AppShell({ title, description, actions, children }: AppShellProps) {
+  return (
+    <div className={styles.shell}>
+      <div className={styles.inner}>
+        <header className={styles.header}>
+          <div>
+            <h1 className={styles.title}>{title}</h1>
+            {description ? <p className={styles.description}>{description}</p> : null}
+          </div>
+          {actions ? <div className={styles.actions}>{actions}</div> : null}
+        </header>
+        <main className={styles.main}>{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/pages/index.module.css
+++ b/apps/webapp/src/pages/index.module.css
@@ -1,0 +1,176 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.metricGrid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 768px) {
+  .metricGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1120px) {
+  .metricGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.55);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cardTitle {
+  margin: 0;
+  color: #1e293b;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.amount {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: #f97316;
+  color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.badge--review {
+  background: #eab308;
+  color: #0f172a;
+}
+
+.subtle {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.trendCard {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(14, 165, 233, 0.05));
+}
+
+.trendMetric {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+
+.trendCaption {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.trendSparkline {
+  width: 100%;
+  height: 64px;
+}
+
+.integrationSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.integrationHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.integrationTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.integrationSubtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.integrationGrid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .integrationGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .integrationGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.integrationTile {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 48px -36px rgba(15, 23, 42, 0.45);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.integrationLabel {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.integrationValue {
+  margin: 0;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.integrationStatus {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #16a34a;
+}
+
+.integrationStatusMonitor {
+  color: #ea580c;
+}

--- a/apps/webapp/src/pages/index.tsx
+++ b/apps/webapp/src/pages/index.tsx
@@ -1,0 +1,145 @@
+import { AppShell } from '../components/AppShell';
+import styles from './index.module.css';
+
+type TrendCard = {
+  id: string;
+  label: string;
+  metric: string;
+  caption: string;
+  stroke: string;
+};
+
+type Integration = {
+  label: string;
+  value: string;
+  status: string;
+  emphasis?: boolean;
+};
+
+const trendCards: TrendCard[] = [
+  {
+    id: 'paygw',
+    label: 'PAYGW 7-Day Trend',
+    metric: '92.3%',
+    caption: 'secured at 92.3% of liability',
+    stroke: '#2563eb',
+  },
+  {
+    id: 'gst',
+    label: 'GST 7-Day Trend',
+    metric: '97.5%',
+    caption: 'secured at 97.5% of liability',
+    stroke: '#0ea5e9',
+  },
+];
+
+const integrations: Integration[] = [
+  { label: 'Payroll System', value: 'Xero Payroll', status: 'Connected' },
+  { label: 'Banking', value: 'CBA API', status: 'Synced' },
+  { label: 'POS', value: 'Square POS', status: 'Monitor', emphasis: true },
+  { label: 'ATO', value: 'STP', status: 'Connected' },
+];
+
+function VarianceBadge() {
+  return <span className={styles.badge}>Shortfall — Requires attention</span>;
+}
+
+function ReviewBadge() {
+  return <span className={`${styles.badge} ${styles['badge--review']}`}>Review — Needs improvement</span>;
+}
+
+function MiniTrend({ id, stroke }: { id: string; stroke: string }) {
+  return (
+    <svg className={styles.trendSparkline} viewBox="0 0 120 40" role="img" aria-labelledby={`${id}-title`}>
+      <title id={`${id}-title`}>7 day trend sparkline</title>
+      <defs>
+        <linearGradient id={`${id}-gradient`} x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor={stroke} stopOpacity="0.35" />
+          <stop offset="100%" stopColor={stroke} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M0 28 C 20 8, 40 34, 60 18 C 80 6, 100 30, 120 16"
+        fill="none"
+        stroke={stroke}
+        strokeWidth="3"
+        strokeLinecap="round"
+        opacity={0.9}
+      />
+      <path
+        d="M0 28 C 20 8, 40 34, 60 18 C 80 6, 100 30, 120 16 L 120 40 L 0 40 Z"
+        fill={`url(#${id}-gradient)`}
+        opacity={0.6}
+      />
+    </svg>
+  );
+}
+
+function IntegrationTile({ label, value, status, emphasis }: Integration) {
+  return (
+    <article className={styles.integrationTile}>
+      <p className={styles.integrationLabel}>{label}</p>
+      <p className={styles.integrationValue}>{value}</p>
+      <p
+        className={`${styles.integrationStatus} ${
+          emphasis ? styles.integrationStatusMonitor : ''
+        }`}
+      >
+        {status}
+      </p>
+    </article>
+  );
+}
+
+export default function OverviewPage() {
+  return (
+    <AppShell title="Business Overview" description="Real-time visibility into cash exposure, compliance, and integration health across your portfolio.">
+      <div className={styles.page}>
+        <section className={styles.metricGrid} aria-label="Key metrics">
+          <article className={styles.card}>
+            <div className={styles.cardHeader}>
+              <h2 className={styles.cardTitle}>Variance Delta</h2>
+              <VarianceBadge />
+            </div>
+            <p className={styles.amount}>$16,850</p>
+            <p className={styles.subtle}>Net variance across monitored liabilities.</p>
+          </article>
+
+          <article className={styles.card}>
+            <div className={styles.cardHeader}>
+              <h2 className={styles.cardTitle}>Overall Compliance</h2>
+              <ReviewBadge />
+            </div>
+            <p className={styles.amount}>94.9%</p>
+            <p className={styles.subtle}>Compliance health benchmarked against regulatory obligations.</p>
+          </article>
+
+          {trendCards.map((card) => (
+            <article key={card.id} className={`${styles.card} ${styles.trendCard}`}>
+              <div className={styles.cardHeader}>
+                <h2 className={styles.cardTitle}>{card.label}</h2>
+              </div>
+              <p className={styles.trendMetric}>{card.metric}</p>
+              <MiniTrend id={card.id} stroke={card.stroke} />
+              <p className={styles.trendCaption}>{card.caption}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className={styles.integrationSection} aria-label="Integration health">
+          <div className={styles.integrationHeader}>
+            <h2 className={styles.integrationTitle}>Integration Health</h2>
+            <p className={styles.integrationSubtitle}>
+              Monitoring connected systems to ensure payroll, banking, and compliance data stays in sync.
+            </p>
+          </div>
+          <div className={styles.integrationGrid}>
+            {integrations.map((integration) => (
+              <IntegrationTile key={integration.label} {...integration} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable AppShell layout wrapper for the webapp routes
- implement the overview dashboard route with key metrics, trend cards, and integration health tiles
- style the new route with responsive grids and elevated card treatments

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f788a61d60832783f6ff20b753fc18