### PR TITLE
feat: add AppShell layout for webapp

### DIFF
--- a/apps/webapp/src/components/AppShell.tsx
+++ b/apps/webapp/src/components/AppShell.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Button } from "./ui/button";
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+import type { LucideIcon } from "lucide-react";
+import {
+  DollarSign,
+  FileWarning,
+  Lock,
+  Menu,
+  Shield,
+  Upload,
+  X,
+} from "lucide-react";
+
+interface NavItem {
+  label: string;
+  value: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    label: "Overview",
+    value: "overview",
+    href: "/",
+    icon: Shield,
+  },
+  {
+    label: "$ PAYGW",
+    value: "paygw",
+    href: "/paygw",
+    icon: DollarSign,
+  },
+  {
+    label: "$ GST",
+    value: "gst",
+    href: "/gst",
+    icon: DollarSign,
+  },
+  {
+    label: "Compliance",
+    value: "compliance",
+    href: "/compliance",
+    icon: FileWarning,
+  },
+  {
+    label: "Security",
+    value: "security",
+    href: "/security",
+    icon: Lock,
+  },
+];
+
+interface AppShellProps {
+  children: ReactNode;
+}
+
+export function AppShell({ children }: AppShellProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const activeValue = useMemo(() => {
+    const activeItem = NAV_ITEMS.find((item) =>
+      item.href === "/"
+        ? location.pathname === "/"
+        : location.pathname.startsWith(item.href)
+    );
+
+    return activeItem?.value ?? NAV_ITEMS[0].value;
+  }, [location.pathname]);
+
+  const handleValueChange = (value: string) => {
+    const target = NAV_ITEMS.find((item) => item.value === value);
+    if (target) {
+      navigate(target.href);
+    }
+  };
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-4">
+          <div className="flex items-center gap-6">
+            <span className="rounded-full bg-primary/10 px-4 py-2 text-lg font-semibold tracking-tight text-primary">
+              APGMS
+            </span>
+            <Tabs
+              value={activeValue}
+              onValueChange={handleValueChange}
+              className="hidden md:block"
+            >
+              <TabsList className="flex gap-1 rounded-full bg-muted/60 p-1">
+                {NAV_ITEMS.map((item) => (
+                  <TabsTrigger
+                    key={item.value}
+                    value={item.value}
+                    className="flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+                  >
+                    <item.icon className="h-4 w-4" />
+                    <span>{item.label}</span>
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              className="md:hidden"
+              onClick={() => setMobileOpen((open) => !open)}
+              aria-label="Toggle navigation menu"
+            >
+              {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+            </Button>
+            <Button className="gap-2 rounded-full bg-primary px-4 py-2 text-primary-foreground shadow-sm hover:bg-primary/90">
+              <Upload className="h-4 w-4" />
+              Export Data
+            </Button>
+          </div>
+        </div>
+        <div className={`${mobileOpen ? "block" : "hidden"} border-t border-border/60 bg-background/95 px-4 pb-4 pt-2 md:hidden`}>
+          <Tabs value={activeValue} onValueChange={handleValueChange} className="w-full">
+            <TabsList className="flex w-full flex-col gap-2 bg-transparent p-0">
+              {NAV_ITEMS.map((item) => (
+                <TabsTrigger
+                  key={item.value}
+                  value={item.value}
+                  className="flex w-full items-center gap-3 rounded-full border border-border/60 px-4 py-2 text-sm font-medium data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
+                >
+                  <item.icon className="h-4 w-4" />
+                  <span>{item.label}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8">{children}</main>
+    </div>
+  );
+}
+
+export default AppShell;

--- a/apps/webapp/src/components/ui/button.tsx
+++ b/apps/webapp/src/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import type { ButtonHTMLAttributes } from "react";
+import { forwardRef } from "react";
+import { cn } from "../../lib/utils";
+
+type ButtonVariant = "default" | "outline" | "secondary" | "ghost";
+type ButtonSize = "default" | "sm" | "lg" | "icon";
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const VARIANT_STYLES: Record<ButtonVariant, string> = {
+  default:
+    "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/40",
+  outline:
+    "border border-border bg-transparent text-foreground hover:bg-muted focus-visible:ring-border",
+  secondary:
+    "bg-muted text-foreground hover:bg-muted/80 focus-visible:ring-muted/60",
+  ghost:
+    "text-foreground hover:bg-muted focus-visible:ring-muted/60",
+};
+
+const SIZE_STYLES: Record<ButtonSize, string> = {
+  default: "h-10 px-4 py-2 text-sm",
+  sm: "h-8 px-3 text-xs",
+  lg: "h-11 px-6 text-base",
+  icon: "h-10 w-10 p-0",
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { className, variant = "default", size = "default", type = "button", ...props },
+    ref,
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          "inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60",
+          VARIANT_STYLES[variant],
+          SIZE_STYLES[size],
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Button.displayName = "Button";

--- a/apps/webapp/src/components/ui/tabs.tsx
+++ b/apps/webapp/src/components/ui/tabs.tsx
@@ -1,0 +1,112 @@
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+} from "react";
+import { createContext, useContext } from "react";
+import { cn } from "../../lib/utils";
+
+interface TabsContextValue {
+  value: string;
+  onValueChange?: (value: string) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | undefined>(undefined);
+
+function useTabsContext(component: string): TabsContextValue {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error(`${component} must be used within Tabs`);
+  }
+  return context;
+}
+
+export interface TabsProps extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+  onValueChange?: (value: string) => void;
+  children: ReactNode;
+}
+
+export function Tabs({ value, onValueChange, className, children }: TabsProps) {
+  return (
+    <TabsContext.Provider value={{ value, onValueChange }}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+export interface TabsListProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function TabsList({ className, children, ...props }: TabsListProps) {
+  return (
+    <div
+      role="tablist"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface TabsTriggerProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export function TabsTrigger({
+  value,
+  className,
+  children,
+  onClick,
+  type = "button",
+  ...props
+}: TabsTriggerProps) {
+  const { value: activeValue, onValueChange } = useTabsContext("TabsTrigger");
+  const isActive = activeValue === value;
+
+  return (
+    <button
+      type={type}
+      role="tab"
+      aria-selected={isActive}
+      data-state={isActive ? "active" : "inactive"}
+      onClick={(event) => {
+        onValueChange?.(value);
+        onClick?.(event);
+      }}
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 data-[state=active]:shadow",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export interface TabsContentProps extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+  children: ReactNode;
+}
+
+export function TabsContent({ value, className, children, ...props }: TabsContentProps) {
+  const { value: activeValue } = useTabsContext("TabsContent");
+  if (activeValue !== value) {
+    return null;
+  }
+
+  return (
+    <div
+      role="tabpanel"
+      data-state="active"
+      className={cn("mt-4", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/webapp/src/lib/utils.ts
+++ b/apps/webapp/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: Array<string | false | null | undefined>) {
+  return inputs.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- add an AppShell layout with tabbed navigation, export button, and mobile menu handling
- implement lightweight shadcn-style button and tabs components along with a cn utility helper

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f7887672548327b7a1380b562540ac