### PR TITLE
feat(webapp): add dashboard ui components

### DIFF
--- a/apps/webapp/src/components/ui/DataTable.tsx
+++ b/apps/webapp/src/components/ui/DataTable.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+
+type SortDirection = "asc" | "desc";
+
+export interface DataTableColumn<T> {
+  key: keyof T;
+  header: React.ReactNode;
+  sortable?: boolean;
+  align?: "left" | "center" | "right";
+  width?: string;
+  render?: (row: T) => React.ReactNode;
+}
+
+export interface DataTableProps<T> {
+  columns: DataTableColumn<T>[];
+  data: T[];
+  initialSort?: {
+    key: keyof T;
+    direction?: SortDirection;
+  };
+  emptyState?: React.ReactNode;
+}
+
+export function DataTable<T>({
+  columns,
+  data,
+  initialSort,
+  emptyState,
+}: DataTableProps<T>) {
+  const [sortKey, setSortKey] = React.useState<keyof T | undefined>(
+    initialSort?.key,
+  );
+  const [direction, setDirection] = React.useState<SortDirection>(
+    initialSort?.direction ?? "asc",
+  );
+
+  const sortedData = React.useMemo(() => {
+    if (!sortKey) {
+      return data;
+    }
+
+    const sorted = [...data].sort((a, b) => {
+      const aValue = a[sortKey];
+      const bValue = b[sortKey];
+
+      if (aValue === bValue) {
+        return 0;
+      }
+
+      if (aValue == null) {
+        return -1;
+      }
+
+      if (bValue == null) {
+        return 1;
+      }
+
+      if (typeof aValue === "number" && typeof bValue === "number") {
+        return aValue - bValue;
+      }
+
+      return String(aValue).localeCompare(String(bValue));
+    });
+
+    return direction === "asc" ? sorted : sorted.reverse();
+  }, [data, sortKey, direction]);
+
+  const handleSort = (key: keyof T, sortable?: boolean) => {
+    if (!sortable) return;
+
+    if (sortKey === key) {
+      setDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setDirection("asc");
+    }
+  };
+
+  return (
+    <div className="w-full overflow-hidden rounded-xl border border-slate-200">
+      <table className="min-w-full divide-y divide-slate-200 text-sm">
+        <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            {columns.map((column) => {
+              const isActive = column.sortable && column.key === sortKey;
+              return (
+                <th
+                  key={String(column.key)}
+                  scope="col"
+                  style={{ width: column.width }}
+                  className={`px-3 py-2 font-semibold ${
+                    column.align === "center"
+                      ? "text-center"
+                      : column.align === "right"
+                        ? "text-right"
+                        : "text-left"
+                  } ${column.sortable ? "cursor-pointer select-none" : ""}`}
+                  onClick={() => handleSort(column.key, column.sortable)}
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {column.header}
+                    {isActive ? (
+                      <span aria-hidden className="text-slate-400">
+                        {direction === "asc" ? "▲" : "▼"}
+                      </span>
+                    ) : column.sortable ? (
+                      <span aria-hidden className="text-slate-300">⇅</span>
+                    ) : null}
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 bg-white">
+          {sortedData.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="px-4 py-6 text-center text-sm text-slate-500"
+              >
+                {emptyState ?? "No data available"}
+              </td>
+            </tr>
+          ) : (
+            sortedData.map((row, rowIndex) => (
+              <tr key={rowIndex} className="hover:bg-slate-50">
+                {columns.map((column) => {
+                  const cellValue = row[column.key];
+                  return (
+                    <td
+                      key={String(column.key)}
+                      className={`px-3 py-2 ${
+                        column.align === "center"
+                          ? "text-center"
+                          : column.align === "right"
+                            ? "text-right"
+                            : "text-left"
+                      } text-slate-700`}
+                    >
+                      {column.render
+                        ? column.render(row)
+                        : ((cellValue ?? "—") as React.ReactNode)}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default DataTable;

--- a/apps/webapp/src/components/ui/GaugeRing.tsx
+++ b/apps/webapp/src/components/ui/GaugeRing.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+export interface GaugeRingProps {
+  value: number;
+  label?: string;
+  size?: number;
+  strokeWidth?: number;
+}
+
+const clamp = (val: number) => Math.min(100, Math.max(0, val));
+
+export const GaugeRing: React.FC<GaugeRingProps> = ({
+  value,
+  label,
+  size = 120,
+  strokeWidth = 12,
+}) => {
+  const normalized = clamp(value);
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (normalized / 100) * circumference;
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 text-center">
+      <svg
+        width={size}
+        height={size}
+        className="text-slate-200"
+        role="img"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={normalized}
+        aria-label={
+          label
+            ? `${label}: ${Math.round(normalized)} percent`
+            : `${Math.round(normalized)} percent`
+        }
+      >
+        <circle
+          className="fill-none stroke-current"
+          strokeWidth={strokeWidth}
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          opacity={0.3}
+        />
+        <circle
+          className="fill-none stroke-emerald-500 transition-all"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          strokeDasharray={`${circumference} ${circumference}`}
+          strokeDashoffset={offset}
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+        <text
+          x="50%"
+          y="50%"
+          dominantBaseline="middle"
+          textAnchor="middle"
+          className="fill-slate-900 text-2xl font-semibold"
+        >
+          {Math.round(normalized)}%
+        </text>
+      </svg>
+      {label ? (
+        <span className="text-sm font-medium text-slate-600">{label}</span>
+      ) : null}
+    </div>
+  );
+};
+
+export default GaugeRing;

--- a/apps/webapp/src/components/ui/HeatCard.tsx
+++ b/apps/webapp/src/components/ui/HeatCard.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+export type HeatTone = "warning" | "good";
+
+export interface HeatCardProps {
+  tone: HeatTone;
+  title: string;
+  period: string;
+  variance: string;
+  confidence: string;
+  footer?: React.ReactNode;
+}
+
+const toneStyles: Record<HeatTone, { container: string; accent: string }> = {
+  warning: {
+    container: "bg-amber-50 border border-amber-200",
+    accent: "text-amber-700",
+  },
+  good: {
+    container: "bg-emerald-50 border border-emerald-200",
+    accent: "text-emerald-700",
+  },
+};
+
+export const HeatCard: React.FC<HeatCardProps> = ({
+  tone,
+  title,
+  period,
+  variance,
+  confidence,
+  footer,
+}) => {
+  const styles = toneStyles[tone];
+  return (
+    <div
+      className={`flex flex-col gap-4 rounded-xl p-5 shadow-sm ${styles.container}`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-slate-500">{period}</p>
+          <h3 className={`text-lg font-semibold ${styles.accent}`}>{title}</h3>
+        </div>
+      </div>
+      <div className="flex items-center gap-6 text-slate-700">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            Variance
+          </p>
+          <p className="text-2xl font-semibold">{variance}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            Confidence
+          </p>
+          <p className="text-2xl font-semibold">{confidence}</p>
+        </div>
+      </div>
+      {footer ? <div className="text-sm text-slate-600">{footer}</div> : null}
+    </div>
+  );
+};
+
+export default HeatCard;

--- a/apps/webapp/src/components/ui/IntegrationTile.tsx
+++ b/apps/webapp/src/components/ui/IntegrationTile.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+type ChipVariant = "default" | "success" | "warning" | "info";
+
+export interface IntegrationTileProps {
+  icon?: React.ReactNode;
+  systemName: string;
+  chipLabel?: string;
+  chipVariant?: ChipVariant;
+  meta?: Array<{ label: string; value: string }>;
+  description?: string;
+  onClick?: () => void;
+}
+
+const chipStyles: Record<ChipVariant, string> = {
+  default: "bg-slate-100 text-slate-600",
+  success: "bg-emerald-100 text-emerald-700",
+  warning: "bg-amber-100 text-amber-700",
+  info: "bg-sky-100 text-sky-700",
+};
+
+export const IntegrationTile: React.FC<IntegrationTileProps> = ({
+  icon,
+  systemName,
+  chipLabel,
+  chipVariant = "default",
+  meta,
+  description,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-4 rounded-xl border border-slate-200 bg-white p-5 text-left shadow-sm transition hover:border-slate-300 hover:shadow"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-100 text-2xl text-slate-600">
+        {icon ?? <span aria-hidden>🔗</span>}
+      </div>
+      <div className="flex flex-1 flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <h3 className="text-base font-semibold text-slate-900">{systemName}</h3>
+          {chipLabel ? (
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${chipStyles[chipVariant]}`}
+            >
+              {chipLabel}
+            </span>
+          ) : null}
+        </div>
+        {description ? (
+          <p className="text-sm text-slate-600">{description}</p>
+        ) : null}
+        {meta && meta.length > 0 ? (
+          <dl className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-slate-500">
+            {meta.map((item) => (
+              <div key={item.label} className="flex gap-1">
+                <dt className="font-medium text-slate-600">{item.label}:</dt>
+                <dd>{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+      </div>
+    </button>
+  );
+};
+
+export default IntegrationTile;

--- a/apps/webapp/src/components/ui/KpiGroup.tsx
+++ b/apps/webapp/src/components/ui/KpiGroup.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+type GapSize = "sm" | "md" | "lg";
+
+export interface KpiGroupProps {
+  children: React.ReactNode;
+  columns?: 1 | 2 | 3 | 4;
+  gap?: GapSize;
+  className?: string;
+}
+
+const gapMap: Record<GapSize, string> = {
+  sm: "gap-3",
+  md: "gap-5",
+  lg: "gap-8",
+};
+
+export const KpiGroup: React.FC<KpiGroupProps> = ({
+  children,
+  columns = 3,
+  gap = "md",
+  className,
+}) => {
+  const columnClass =
+    columns === 4
+      ? "md:grid-cols-2 xl:grid-cols-4"
+      : columns === 2
+        ? "md:grid-cols-2"
+        : columns === 1
+          ? "grid-cols-1"
+          : "md:grid-cols-3";
+
+  return (
+    <div
+      className={`grid grid-cols-1 ${columnClass} ${gapMap[gap]} ${
+        className ?? ""
+      }`.trim()}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default KpiGroup;

--- a/apps/webapp/src/components/ui/MiniTrend.tsx
+++ b/apps/webapp/src/components/ui/MiniTrend.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  ReferenceLine,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export interface MiniTrendDatum {
+  x: number;
+  y: number;
+}
+
+export interface MiniTrendProps {
+  data: MiniTrendDatum[];
+  targetPct?: number;
+  stroke?: string;
+}
+
+const tooltipStyles = {
+  backgroundColor: "white",
+  border: "1px solid rgba(148, 163, 184, 0.4)",
+  borderRadius: "0.5rem",
+  padding: "0.375rem 0.75rem",
+};
+
+export const MiniTrend: React.FC<MiniTrendProps> = ({
+  data,
+  targetPct,
+  stroke = "#0f172a",
+}) => {
+  return (
+    <div className="h-20 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 6, right: 6, left: 6, bottom: 6 }}>
+          <XAxis dataKey="x" hide type="number" domain={["dataMin", "dataMax"]} />
+          <YAxis hide type="number" domain={["dataMin", "dataMax"]} />
+          {typeof targetPct === "number" ? (
+            <ReferenceLine
+              y={targetPct}
+              stroke="#22c55e"
+              strokeDasharray="3 3"
+              strokeWidth={1}
+            />
+          ) : null}
+          <Line
+            type="monotone"
+            dataKey="y"
+            stroke={stroke}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <Tooltip
+            cursor={{ stroke: "rgba(148, 163, 184, 0.4)", strokeWidth: 1 }}
+            wrapperStyle={tooltipStyles}
+            labelFormatter={(value) => `Index ${value}`}
+            formatter={(value: number) => [`${value.toFixed(1)}%`, "Value"]}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default MiniTrend;

--- a/apps/webapp/src/components/ui/SegmentTabs.tsx
+++ b/apps/webapp/src/components/ui/SegmentTabs.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+export interface SegmentTabOption {
+  value: string;
+  label: string;
+  badge?: string | number;
+}
+
+export interface SegmentTabsProps {
+  options: SegmentTabOption[];
+  value: string;
+  onValueChange?: (value: string) => void;
+  ariaLabel?: string;
+}
+
+export const SegmentTabs: React.FC<SegmentTabsProps> = ({
+  options,
+  value,
+  onValueChange,
+  ariaLabel,
+}) => {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="inline-flex items-center justify-center gap-1 rounded-full border border-slate-200 bg-slate-100 p-1 text-sm"
+    >
+      {options.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            key={option.value}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            onClick={() => onValueChange?.(option.value)}
+            className={`flex items-center gap-2 rounded-full px-4 py-1.5 font-medium transition ${
+              isActive
+                ? "bg-white text-slate-900 shadow"
+                : "text-slate-500 hover:text-slate-800"
+            }`}
+          >
+            <span>{option.label}</span>
+            {option.badge !== undefined ? (
+              <span
+                className={`inline-flex min-w-[1.5rem] items-center justify-center rounded-full px-1 text-xs font-semibold ${
+                  isActive
+                    ? "bg-slate-900 text-white"
+                    : "bg-white/60 text-slate-600"
+                }`}
+              >
+                {option.badge}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SegmentTabs;

--- a/apps/webapp/src/components/ui/SliderRow.tsx
+++ b/apps/webapp/src/components/ui/SliderRow.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+export interface SliderRowProps {
+  label: string;
+  description?: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  onValueChange: (value: number) => void;
+  id?: string;
+}
+
+export const SliderRow: React.FC<SliderRowProps> = ({
+  label,
+  description,
+  value,
+  min = 0,
+  max = 100,
+  step = 1,
+  unit,
+  onValueChange,
+  id,
+}) => {
+  return (
+    <label
+      htmlFor={id}
+      className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4"
+    >
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex flex-col">
+          <span className="font-medium text-slate-900">{label}</span>
+          {description ? (
+            <span className="text-xs text-slate-500">{description}</span>
+          ) : null}
+        </div>
+        <span className="text-sm font-semibold text-slate-800">
+          {value}
+          {unit ? <span className="ml-1 text-xs text-slate-500">{unit}</span> : null}
+        </span>
+      </div>
+      <input
+        type="range"
+        id={id}
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onValueChange(Number(event.target.value))}
+        className="h-1 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-emerald-500"
+      />
+    </label>
+  );
+};
+
+export default SliderRow;

--- a/apps/webapp/src/components/ui/StatCard.tsx
+++ b/apps/webapp/src/components/ui/StatCard.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+export interface StatCardProps {
+  title: string;
+  subtitle?: string;
+  value: string | number;
+  subtext?: string;
+  rightBadge?: React.ReactNode;
+}
+
+export const StatCard: React.FC<StatCardProps> = ({
+  title,
+  subtitle,
+  value,
+  subtext,
+  rightBadge,
+}) => {
+  return (
+    <div className="relative flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          {subtitle ? (
+            <p className="text-sm font-medium text-slate-500">{subtitle}</p>
+          ) : null}
+          <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+        </div>
+        {rightBadge ? (
+          <div className="shrink-0 text-right text-sm font-medium text-slate-500">
+            {rightBadge}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-4xl font-semibold tracking-tight text-slate-900">
+          {value}
+        </span>
+        {subtext ? (
+          <p className="text-sm text-slate-500">{subtext}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default StatCard;

--- a/apps/webapp/src/components/ui/SwitchRow.tsx
+++ b/apps/webapp/src/components/ui/SwitchRow.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+export interface SwitchRowProps {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+}
+
+export const SwitchRow: React.FC<SwitchRowProps> = ({
+  label,
+  description,
+  checked,
+  onCheckedChange,
+  disabled,
+  id,
+}) => {
+  const handleToggle = () => {
+    if (disabled) return;
+    onCheckedChange(!checked);
+  };
+
+  return (
+    <div
+      className={`flex items-start justify-between gap-4 rounded-lg border border-slate-200 bg-white p-4 transition hover:border-slate-300 ${
+        disabled ? "opacity-60" : "cursor-pointer"
+      }`}
+      onClick={handleToggle}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleToggle();
+        }
+      }}
+      aria-disabled={disabled}
+    >
+      <span className="flex flex-col" id={id ? `${id}-label` : undefined}>
+        <span className="text-sm font-medium text-slate-900">{label}</span>
+        {description ? (
+          <span className="text-xs text-slate-500">{description}</span>
+        ) : null}
+      </span>
+      <span className="mt-1 inline-flex items-center">
+        <span
+          role="switch"
+          aria-checked={checked}
+          aria-labelledby={id ? `${id}-label` : undefined}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full border transition ${
+            checked
+              ? "border-emerald-500 bg-emerald-500"
+              : "border-slate-300 bg-slate-200"
+          }`}
+        >
+          <span
+            className={`absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+              checked ? "translate-x-5" : "translate-x-0"
+            }`}
+          />
+        </span>
+      </span>
+    </div>
+  );
+};
+
+export default SwitchRow;

--- a/apps/webapp/src/components/ui/VarianceBadge.tsx
+++ b/apps/webapp/src/components/ui/VarianceBadge.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+export type VarianceBadgeVariant = "success" | "warning" | "danger" | "info";
+
+export interface VarianceBadgeProps {
+  label: string;
+  variant?: VarianceBadgeVariant;
+  percentage?: number;
+  className?: string;
+}
+
+const variantStyles: Record<VarianceBadgeVariant, string> = {
+  success:
+    "bg-emerald-100 text-emerald-700 border border-emerald-200",
+  warning:
+    "bg-amber-100 text-amber-800 border border-amber-200",
+  danger: "bg-rose-100 text-rose-700 border border-rose-200",
+  info: "bg-sky-100 text-sky-700 border border-sky-200",
+};
+
+export const VarianceBadge: React.FC<VarianceBadgeProps> = ({
+  label,
+  variant = "info",
+  percentage,
+  className,
+}) => {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium ${variantStyles[variant]} ${className ?? ""}`.trim()}
+    >
+      {label}
+      {typeof percentage === "number" && !Number.isNaN(percentage) ? (
+        <span className="text-xs font-semibold opacity-80">
+          {percentage > 0 ? "+" : ""}
+          {percentage.toFixed(1)}%
+        </span>
+      ) : null}
+    </span>
+  );
+};
+
+export default VarianceBadge;

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,8 @@
     "dependencies":  {
                          "react":  "^18.3.1",
                          "react-dom":  "^18.3.1",
-                         "react-router-dom":  "^6.26.2"
+                         "react-router-dom":  "^6.26.2",
+                         "recharts": "^2.12.7"
                      },
     "devDependencies":  {
                             "@axe-core/playwright":  "^4.9.0",


### PR DESCRIPTION
## Summary
- add stat, gauge, badge, heat, and integration tiles for KPI dashboards
- create trend, segmented tabs, slider/switch rows, and KPI grid helpers
- build a generic sortable data table and add recharts dependency for sparklines

## Testing
- pnpm install *(fails: registry returned 403 while fetching recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68f78885c9c88327947a70ba4cae790a