### PR TITLE
Add obligations route coverage and accessibility checks

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import HomePage from './pages/Home';
 import BankLinesPage from './pages/BankLines';
+import PaygwPage from './pages/Paygw';
+import GstPage from './pages/Gst';
+import CompliancePage from './pages/Compliance';
+import SecurityPage from './pages/Security';
 import './App.css';
 
 type Theme = 'light' | 'dark';
@@ -42,7 +46,19 @@ export default function App() {
         <div className="app__brand">APGMS Pro+</div>
         <nav className="app__nav" aria-label="Primary">
           <NavLink className="app__nav-link" to="/" end>
-            Overview
+            Obligations
+          </NavLink>
+          <NavLink className="app__nav-link" to="/paygw">
+            PAYGW
+          </NavLink>
+          <NavLink className="app__nav-link" to="/gst">
+            GST
+          </NavLink>
+          <NavLink className="app__nav-link" to="/compliance">
+            Compliance
+          </NavLink>
+          <NavLink className="app__nav-link" to="/security">
+            Security
           </NavLink>
           <NavLink className="app__nav-link" to="/bank-lines">
             Bank lines
@@ -60,11 +76,15 @@ export default function App() {
       <main className="app__content">
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/paygw" element={<PaygwPage />} />
+          <Route path="/gst" element={<GstPage />} />
+          <Route path="/compliance" element={<CompliancePage />} />
+          <Route path="/security" element={<SecurityPage />} />
           <Route path="/bank-lines" element={<BankLinesPage />} />
         </Routes>
       </main>
       <footer className="app__footer">
-        <p>Portfolio monitoring built for institutional capital teams.</p>
+        <p>Obligation management built for institutional finance teams.</p>
       </footer>
     </div>
   );

--- a/webapp/src/pages/Compliance.tsx
+++ b/webapp/src/pages/Compliance.tsx
@@ -1,0 +1,91 @@
+import './ObligationDetail.css';
+
+const complianceChecks = [
+  {
+    title: 'ASIC annual solvency resolution',
+    due: '30 September 2024',
+    status: 'Board review scheduled',
+  },
+  {
+    title: 'Modern slavery statement',
+    due: '31 December 2024',
+    status: 'Drafting with legal',
+  },
+  {
+    title: 'AFS license variation report',
+    due: '15 November 2024',
+    status: 'Awaiting supporting evidence',
+  },
+] as const;
+
+const policyTasks = [
+  {
+    title: 'Update enterprise risk matrix',
+    owner: 'Risk & compliance',
+    status: 'Due next week',
+  },
+  {
+    title: 'Refresh business continuity test plan',
+    owner: 'Operations',
+    status: 'Draft ready',
+  },
+  {
+    title: 'Circulate whistleblower training pack',
+    owner: 'People & culture',
+    status: 'Pending distribution',
+  },
+] as const;
+
+export default function CompliancePage() {
+  return (
+    <div className="obligation-page">
+      <header className="obligation-page__header">
+        <h1>Compliance obligations</h1>
+        <p>
+          Surface regulatory filings, board approvals, and internal assurance actions needed to stay
+          audit-ready.
+        </p>
+      </header>
+
+      <section aria-labelledby="compliance-register" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="compliance-register">Register</h2>
+          <p className="obligation-page__section-description">
+            Core filings and declarations across financial services and corporate governance.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {complianceChecks.map((item) => (
+            <li key={item.title} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{item.title}</p>
+                <p className="obligation-page__item-meta">Due {item.due}</p>
+              </div>
+              <span className="obligation-page__item-status">{item.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="compliance-actions" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="compliance-actions">Action items</h2>
+          <p className="obligation-page__section-description">
+            Policy reviews and readiness tasks owned by first-line teams.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {policyTasks.map((task) => (
+            <li key={task.title} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{task.title}</p>
+                <p className="obligation-page__item-meta">Owner: {task.owner}</p>
+              </div>
+              <span className="obligation-page__item-status">{task.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/webapp/src/pages/Gst.tsx
+++ b/webapp/src/pages/Gst.tsx
@@ -1,0 +1,91 @@
+import './ObligationDetail.css';
+
+const gstReturns = [
+  {
+    period: 'Q4 FY24 BAS',
+    due: '28 August 2024',
+    status: 'Ready for CFO sign-off',
+  },
+  {
+    period: 'Q1 FY25 BAS',
+    due: '28 October 2024',
+    status: 'Data gathering in progress',
+  },
+  {
+    period: 'Annual GST adjustment',
+    due: '15 January 2025',
+    status: 'Waiting on asset register',
+  },
+] as const;
+
+const reconciliationTasks = [
+  {
+    title: 'Cross-check business activity statement draft',
+    owner: 'Finance systems',
+    status: 'Due tomorrow',
+  },
+  {
+    title: 'Validate GST-free sales exceptions',
+    owner: 'Compliance analytics',
+    status: 'In progress',
+  },
+  {
+    title: 'Upload new AP invoice mapping rules',
+    owner: 'Accounts payable',
+    status: 'Ready to review',
+  },
+] as const;
+
+export default function GstPage() {
+  return (
+    <div className="obligation-page">
+      <header className="obligation-page__header">
+        <h1>GST obligations</h1>
+        <p>
+          Review BAS cycles, data integrity checks, and outstanding reconciliations for Goods and
+          Services Tax reporting.
+        </p>
+      </header>
+
+      <section aria-labelledby="gst-return-schedule" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="gst-return-schedule">Return schedule</h2>
+          <p className="obligation-page__section-description">
+            Live visibility of business activity statements and long-lead adjustments.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {gstReturns.map((gstReturn) => (
+            <li key={gstReturn.period} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{gstReturn.period}</p>
+                <p className="obligation-page__item-meta">Due {gstReturn.due}</p>
+              </div>
+              <span className="obligation-page__item-status">{gstReturn.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="gst-reconciliation" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="gst-reconciliation">Reconciliation workflow</h2>
+          <p className="obligation-page__section-description">
+            Tasks required to reconcile ledgers ahead of the next BAS submission.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {reconciliationTasks.map((task) => (
+            <li key={task.title} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{task.title}</p>
+                <p className="obligation-page__item-meta">Owner: {task.owner}</p>
+              </div>
+              <span className="obligation-page__item-status">{task.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -44,10 +44,10 @@ export default function HomePage() {
   return (
     <div className="page">
       <header className="page__header">
-        <h1>Portfolio pulse</h1>
+        <h1>Obligations</h1>
         <p>
-          Monitor capital utilization, track live mandates, and surface emerging risk signals
-          across your institutional banking relationships.
+          Monitor upcoming lodgements, statutory reporting, and operational follow-ups across
+          every government obligation in a single workspace.
         </p>
       </header>
 

--- a/webapp/src/pages/ObligationDetail.css
+++ b/webapp/src/pages/ObligationDetail.css
@@ -1,0 +1,80 @@
+.obligation-page {
+  display: grid;
+  gap: var(--spacing-2xl);
+  padding-top: var(--spacing-2xl);
+}
+
+.obligation-page__header {
+  display: grid;
+  gap: var(--spacing-sm);
+  max-width: 48rem;
+}
+
+.obligation-page__header h1 {
+  font-size: var(--font-size-2xl);
+  letter-spacing: -0.03em;
+}
+
+.obligation-page__header p {
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
+}
+
+.obligation-page__section {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.obligation-page__section-header {
+  display: grid;
+  gap: var(--spacing-2xs);
+}
+
+.obligation-page__section-description {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.obligation-page__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.obligation-page__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-lg);
+}
+
+.obligation-page__item-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-medium);
+}
+
+.obligation-page__item-meta {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.obligation-page__item-status {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-primary);
+}
+
+@media (max-width: 720px) {
+  .obligation-page__item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-sm);
+  }
+}

--- a/webapp/src/pages/Paygw.tsx
+++ b/webapp/src/pages/Paygw.tsx
@@ -1,0 +1,91 @@
+import './ObligationDetail.css';
+
+const upcomingSubmissions = [
+  {
+    period: 'Fortnight ending 15 July',
+    due: '21 August 2024',
+    status: 'Awaiting payroll reconciliation',
+  },
+  {
+    period: 'Fortnight ending 31 July',
+    due: '4 September 2024',
+    status: 'Draft in Xero',
+  },
+  {
+    period: 'Fortnight ending 15 August',
+    due: '18 September 2024',
+    status: 'Pending CFO approval',
+  },
+] as const;
+
+const actionItems = [
+  {
+    title: 'Match Single Touch Payroll totals',
+    owner: 'Payroll operations',
+    status: 'Due in 2 days',
+  },
+  {
+    title: 'Confirm consolidated group remitter status',
+    owner: 'Tax advisory',
+    status: 'In review',
+  },
+  {
+    title: 'Upload withholding variance memo',
+    owner: 'Financial controller',
+    status: 'Ready for sign-off',
+  },
+] as const;
+
+export default function PaygwPage() {
+  return (
+    <div className="obligation-page">
+      <header className="obligation-page__header">
+        <h1>PAYGW obligations</h1>
+        <p>
+          Track upcoming pay-as-you-go withholding lodgements, ownership, and approval checkpoints
+          before monthly submissions are due.
+        </p>
+      </header>
+
+      <section aria-labelledby="paygw-upcoming" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="paygw-upcoming">Upcoming submissions</h2>
+          <p className="obligation-page__section-description">
+            Consolidated calendar of withholding periods and their statutory due dates.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {upcomingSubmissions.map((submission) => (
+            <li key={submission.period} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{submission.period}</p>
+                <p className="obligation-page__item-meta">Due {submission.due}</p>
+              </div>
+              <span className="obligation-page__item-status">{submission.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="paygw-actions" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="paygw-actions">Workflow</h2>
+          <p className="obligation-page__section-description">
+            Operational follow-ups required ahead of each submission cycle.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {actionItems.map((item) => (
+            <li key={item.title} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{item.title}</p>
+                <p className="obligation-page__item-meta">Owner: {item.owner}</p>
+              </div>
+              <span className="obligation-page__item-status">{item.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/webapp/src/pages/Security.tsx
+++ b/webapp/src/pages/Security.tsx
@@ -1,0 +1,91 @@
+import './ObligationDetail.css';
+
+const assessments = [
+  {
+    title: 'APRA CPS 234 control attestation',
+    due: '12 September 2024',
+    status: 'Evidence gathering',
+  },
+  {
+    title: 'Vendor penetration test (CorePay)',
+    due: '7 October 2024',
+    status: 'Testing underway',
+  },
+  {
+    title: 'IRAP refresh',
+    due: '30 November 2024',
+    status: 'Scheduling with assessor',
+  },
+] as const;
+
+const securityTasks = [
+  {
+    title: 'Roll out hardware security keys to finance team',
+    owner: 'Identity & access',
+    status: '40% complete',
+  },
+  {
+    title: 'Review data retention policy exceptions',
+    owner: 'Security governance',
+    status: 'Blocked pending legal feedback',
+  },
+  {
+    title: 'Update incident response playbook',
+    owner: 'Cyber defence',
+    status: 'Draft ready',
+  },
+] as const;
+
+export default function SecurityPage() {
+  return (
+    <div className="obligation-page">
+      <header className="obligation-page__header">
+        <h1>Security obligations</h1>
+        <p>
+          Align control attestations, vendor testing, and remediation follow-ups in one place for
+          security and risk stakeholders.
+        </p>
+      </header>
+
+      <section aria-labelledby="security-assessments" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="security-assessments">Assessments</h2>
+          <p className="obligation-page__section-description">
+            Oversight of regulatory, customer, and third-party security requirements.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {assessments.map((assessment) => (
+            <li key={assessment.title} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{assessment.title}</p>
+                <p className="obligation-page__item-meta">Due {assessment.due}</p>
+              </div>
+              <span className="obligation-page__item-status">{assessment.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="security-actions" className="obligation-page__section">
+        <div className="obligation-page__section-header">
+          <h2 id="security-actions">Follow-ups</h2>
+          <p className="obligation-page__section-description">
+            Outstanding remediation items across identity, governance, and incident response.
+          </p>
+        </div>
+        <ul className="obligation-page__list">
+          {securityTasks.map((task) => (
+            <li key={task.title} className="obligation-page__item">
+              <div>
+                <p className="obligation-page__item-title">{task.title}</p>
+                <p className="obligation-page__item-meta">Owner: {task.owner}</p>
+              </div>
+              <span className="obligation-page__item-status">{task.status}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/webapp/tests/a11y.spec.ts
+++ b/webapp/tests/a11y.spec.ts
@@ -1,10 +1,9 @@
-﻿import AxeBuilder from '@axe-core/playwright';
-import { test, expect } from '@playwright/test';
-
-const ROUTES = ['/', '/bank-lines'] as const;
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import { ACCESSIBILITY_ROUTES } from './routes';
 
 test.describe('Accessibility regression checks', () => {
-  for (const route of ROUTES) {
+  for (const route of ACCESSIBILITY_ROUTES) {
     test(`ensures ${route} meets WCAG 2.1 AA requirements`, async ({ page }, testInfo) => {
       await page.goto(route);
       await page.waitForLoadState('networkidle');
@@ -13,7 +12,9 @@ test.describe('Accessibility regression checks', () => {
         .withTags(['wcag2a', 'wcag2aa'])
         .analyze();
 
-      await testInfo.attach(`axe-results-${route === '/' ? 'home' : 'bank-lines'}`, {
+      const label = route === '/' ? 'home' : route.replace('/', '') || 'home';
+
+      await testInfo.attach(`axe-results-${label}`, {
         body: JSON.stringify(results, null, 2),
         contentType: 'application/json',
       });

--- a/webapp/tests/axe.spec.ts
+++ b/webapp/tests/axe.spec.ts
@@ -1,9 +1,8 @@
-﻿import AxeBuilder from '@axe-core/playwright';
+import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
+import { ACCESSIBILITY_ROUTES } from './routes';
 
-const routes = ['/', '/bank-lines'] as const;
-
-for (const route of routes) {
+for (const route of ACCESSIBILITY_ROUTES) {
   test.describe(`Accessibility for ${route}`, () => {
     test(`should have no detectable Axe violations on ${route}`, async ({ page }) => {
       await page.goto(route);

--- a/webapp/tests/routes.spec.ts
+++ b/webapp/tests/routes.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+import { PRIMARY_ROUTE_CONFIG } from './routes';
+
+test.describe('Obligation routes', () => {
+  for (const route of PRIMARY_ROUTE_CONFIG) {
+    test(`renders expected heading for ${route.path}`, async ({ page }) => {
+      await page.goto(route.path);
+      await page.waitForLoadState('networkidle');
+
+      const heading = page.getByRole('heading', { level: 1 });
+      if (route.match === 'exact') {
+        await expect(heading).toHaveText(route.heading);
+      } else {
+        await expect(heading).toContainText(route.heading);
+      }
+    });
+  }
+});

--- a/webapp/tests/routes.ts
+++ b/webapp/tests/routes.ts
@@ -1,0 +1,16 @@
+export const PRIMARY_ROUTE_CONFIG = [
+  { path: '/', heading: 'Obligations', match: 'exact' as const },
+  { path: '/paygw', heading: 'PAYGW' },
+  { path: '/gst', heading: 'GST' },
+  { path: '/compliance', heading: 'Compliance' },
+  { path: '/security', heading: 'Security' },
+] as const;
+
+export const ACCESSIBILITY_ROUTES = [
+  '/',
+  '/paygw',
+  '/gst',
+  '/compliance',
+  '/security',
+  '/bank-lines',
+] as const;


### PR DESCRIPTION
## Summary
- add dedicated PAYGW, GST, Compliance, and Security obligation pages and expose them via the main navigation
- update the overview copy to focus on obligations and introduce shared styling for detail sections
- add Playwright smoke checks for key routes and expand axe-based accessibility coverage

## Testing
- pnpm --filter @apgms/webapp test *(fails: Playwright browsers are unavailable in this environment)*
- pnpm exec playwright install *(fails: upstream download URL returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f76936e90c8327b2045cb44d37d668