### PR TITLE
Use design tokens in Bank Lines styling

### DIFF
--- a/webapp/src/pages/BankLines.css
+++ b/webapp/src/pages/BankLines.css
@@ -14,13 +14,13 @@
 
 .bank-lines__header h1 {
   font-size: var(--font-size-2xl);
-  letter-spacing: -0.03em;
+  letter-spacing: var(--font-letterspacing-tight);
 }
 
 .bank-lines__header p {
   margin-top: var(--spacing-xs);
   color: var(--color-text-muted);
-  max-width: 40rem;
+  max-width: var(--layout-measure-md);
 }
 
 .bank-lines__cta {
@@ -36,8 +36,8 @@
 }
 
 .bank-lines__cta:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--color-focus);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .bank-lines__table-wrapper {
@@ -83,7 +83,7 @@ tbody tr + tr {
 
 .bank-lines__utilization-track {
   position: relative;
-  height: 0.4rem;
+  height: var(--size-progress-thickness);
   background-color: var(--color-surface-muted);
   border-radius: var(--radius-pill);
   overflow: hidden;
@@ -105,7 +105,7 @@ tbody tr + tr {
   border-radius: var(--radius-md);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
-  letter-spacing: 0.04em;
+  letter-spacing: var(--font-letterspacing-wide);
   text-transform: uppercase;
 }
 
@@ -114,23 +114,23 @@ tbody tr + tr {
 }
 
 .status-badge__hint {
-  font-size: var(--font-size-xxs, 0.65rem);
-  opacity: 0.85;
+  font-size: var(--font-size-xxs);
+  opacity: var(--opacity-muted-strong);
 }
 
 .status-badge--active {
-  background-color: rgba(10, 125, 87, 0.16);
-  color: var(--color-success);
+  background-color: var(--status-active-bg);
+  color: var(--status-active-fg);
 }
 
 .status-badge--pending {
-  background-color: rgba(185, 115, 24, 0.18);
-  color: var(--color-warning);
+  background-color: var(--status-pending-bg);
+  color: var(--status-pending-fg);
 }
 
 .status-badge--monitoring {
-  background-color: var(--color-primary-soft);
-  color: var(--color-primary);
+  background-color: var(--status-monitor-bg);
+  color: var(--status-monitor-fg);
 }
 
 .sr-only {

--- a/webapp/src/styles/tokens.css
+++ b/webapp/src/styles/tokens.css
@@ -31,6 +31,7 @@
   --radius-pill: 999px;
 
   --font-family-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-size-xxs: 0.65rem;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;
@@ -40,9 +41,20 @@
   --font-weight-regular: 400;
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
+  --font-letterspacing-tight: -0.03em;
+  --font-letterspacing-wide: 0.04em;
   --font-lineheight-tight: 1.2;
   --font-lineheight-cozy: 1.4;
   --font-lineheight-relaxed: 1.6;
+
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+
+  --opacity-muted-strong: 0.85;
+
+  --layout-measure-md: 40rem;
+
+  --size-progress-thickness: 0.4rem;
 
   --shadow-sm: 0 6px 18px rgba(15, 23, 42, 0.08);
   --shadow-md: 0 16px 35px rgba(15, 23, 42, 0.15);


### PR DESCRIPTION
## Summary
- replace raw spacing, typographic, and color values in the Bank Lines page with design tokens
- add tokens covering compact typography, focus outlines, and progress indicator sizing for reuse

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f76928e7348327bc64e37c0aae9f40