### PR TITLE
feat(webapp): scaffold mocked API hooks and loading states

### DIFF
--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1,0 +1,189 @@
+import type {
+  AuditTrailItem,
+  Connection,
+  GstVariance,
+  Obligation,
+  PaygwQueueItem
+} from './types';
+
+const FETCH_DELAY = 600;
+
+type FetchOptions = {
+  signal?: AbortSignal;
+};
+
+const mockObligations: Obligation[] = [
+  {
+    id: 'obligation-1',
+    name: 'PAYG remittance - Australia',
+    amount: '$215,420',
+    dueDate: 'Due in 3 days',
+    status: 'Due soon',
+    commentary: 'Confirm withheld amounts after this week\'s payroll close.'
+  },
+  {
+    id: 'obligation-2',
+    name: 'SG superannuation top-up',
+    amount: '$86,000',
+    dueDate: 'Scheduled 18 Oct',
+    status: 'Monitoring',
+    commentary: 'Waiting on confirmation from Melbourne subsidiary finance lead.'
+  },
+  {
+    id: 'obligation-3',
+    name: 'PAYG catch-up - New Zealand',
+    amount: 'NZ$54,280',
+    dueDate: 'Filed 2 days ago',
+    status: 'Paid',
+    commentary: 'Settled with IRD. Reconcile in Workpapers prior to month end.'
+  }
+];
+
+const mockPaygwQueue: PaygwQueueItem[] = [
+  {
+    id: 'queue-1',
+    employer: 'Northwind Manufacturing',
+    amount: '$84,200',
+    payPeriod: 'Fortnight ending 11 Oct',
+    status: 'Queued',
+    nextAction: 'Validate overtime adjustments before submission.'
+  },
+  {
+    id: 'queue-2',
+    employer: 'Brightside Retail Group',
+    amount: '$41,930',
+    payPeriod: 'Monthly close 30 Sep',
+    status: 'Requires attention',
+    nextAction: 'Payroll variance exceeds 5% - flag with controller.'
+  },
+  {
+    id: 'queue-3',
+    employer: 'Helios Energy JV',
+    amount: '$57,610',
+    payPeriod: 'Fortnight ending 4 Oct',
+    status: 'Processing',
+    nextAction: 'ATO lodgement in-flight. Expect confirmation this afternoon.'
+  }
+];
+
+const mockGstVariance: GstVariance = {
+  id: 'gst-variance-1',
+  entity: 'APAC consolidated',
+  variance: 4.6,
+  direction: 'Decrease',
+  narrative: 'Variance driven by accelerated input tax credits for Q1 solar deployments.',
+  updated: 'Updated 9 Oct'
+};
+
+const mockAuditTrail: AuditTrailItem[] = [
+  {
+    id: 'audit-1',
+    actor: 'S. Patel',
+    action: 'Approved updated PAYG submission',
+    timestamp: 'Today · 10:42 AEDT',
+    context: 'Northwind Manufacturing payroll cycle'
+  },
+  {
+    id: 'audit-2',
+    actor: 'M. Chen',
+    action: 'Reconciled GST variance report',
+    timestamp: 'Yesterday · 16:10 AEDT',
+    context: 'Q3 APAC consolidated filings'
+  },
+  {
+    id: 'audit-3',
+    actor: 'K. Robinson',
+    action: 'Requested supporting docs from syndicate partner',
+    timestamp: '2 days ago',
+    context: 'Helios Energy JV compliance pack'
+  }
+];
+
+const mockConnections: Connection[] = [
+  {
+    id: 'connection-1',
+    bank: 'Commonwealth Bank',
+    limit: '$1.2B',
+    utilization: '64%',
+    status: 'Active',
+    updated: 'Today 10:24',
+    notes: 'Term sheet expansion approved for Helios storage facility.'
+  },
+  {
+    id: 'connection-2',
+    bank: 'Northwind Credit Union',
+    limit: '$820M',
+    utilization: '71%',
+    status: 'Monitoring',
+    updated: 'Yesterday',
+    notes: 'Utilization trending upward ahead of portfolio rebalance.'
+  },
+  {
+    id: 'connection-3',
+    bank: 'First Harbor Partners',
+    limit: '$640M',
+    utilization: '48%',
+    status: 'Pending',
+    updated: '2 days ago',
+    notes: 'Awaiting revised covenants from legal after counterparty feedback.'
+  }
+];
+
+function clonePayload<T>(payload: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(payload);
+  }
+
+  return JSON.parse(JSON.stringify(payload)) as T;
+}
+
+function simulateFetch<T>(payload: T, signal?: AbortSignal): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', handleAbort);
+      resolve(clonePayload(payload));
+    }, FETCH_DELAY);
+
+    const handleAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        handleAbort();
+        return;
+      }
+
+      signal.addEventListener('abort', handleAbort, { once: true });
+    }
+  });
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null && 'name' in error) {
+    return (error as { name?: string }).name === 'AbortError';
+  }
+
+  return false;
+}
+
+export function getObligations(options: FetchOptions = {}): Promise<Obligation[]> {
+  return simulateFetch(mockObligations, options.signal);
+}
+
+export function getPaygwQueue(options: FetchOptions = {}): Promise<PaygwQueueItem[]> {
+  return simulateFetch(mockPaygwQueue, options.signal);
+}
+
+export function getGstVariance(options: FetchOptions = {}): Promise<GstVariance> {
+  return simulateFetch(mockGstVariance, options.signal);
+}
+
+export function getAuditTrail(options: FetchOptions = {}): Promise<AuditTrailItem[]> {
+  return simulateFetch(mockAuditTrail, options.signal);
+}
+
+export function getConnections(options: FetchOptions = {}): Promise<Connection[]> {
+  return simulateFetch(mockConnections, options.signal);
+}

--- a/webapp/src/lib/types.ts
+++ b/webapp/src/lib/types.ts
@@ -1,0 +1,52 @@
+export type ObligationStatus = 'Due soon' | 'Monitoring' | 'Paid';
+
+export type Obligation = {
+  id: string;
+  name: string;
+  amount: string;
+  dueDate: string;
+  status: ObligationStatus;
+  commentary: string;
+};
+
+export type PaygwQueueStatus = 'Queued' | 'Processing' | 'Requires attention';
+
+export type PaygwQueueItem = {
+  id: string;
+  employer: string;
+  amount: string;
+  payPeriod: string;
+  status: PaygwQueueStatus;
+  nextAction: string;
+};
+
+export type GstVarianceDirection = 'Increase' | 'Decrease';
+
+export type GstVariance = {
+  id: string;
+  entity: string;
+  variance: number;
+  direction: GstVarianceDirection;
+  narrative: string;
+  updated: string;
+};
+
+export type AuditTrailItem = {
+  id: string;
+  actor: string;
+  action: string;
+  timestamp: string;
+  context: string;
+};
+
+export type ConnectionStatus = 'Active' | 'Pending' | 'Monitoring';
+
+export type Connection = {
+  id: string;
+  bank: string;
+  limit: string;
+  utilization: string;
+  status: ConnectionStatus;
+  updated: string;
+  notes: string;
+};

--- a/webapp/src/pages/BankLines.css
+++ b/webapp/src/pages/BankLines.css
@@ -133,6 +133,56 @@ tbody tr + tr {
   color: var(--color-primary);
 }
 
+.bank-lines__message {
+  text-align: center;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  color: var(--color-text-muted);
+}
+
+.bank-lines__message h2 {
+  margin-bottom: var(--spacing-xs);
+  color: var(--color-text);
+  font-size: var(--font-size-lg);
+}
+
+.bank-lines__message p {
+  margin: 0;
+  max-width: 36rem;
+  margin-inline: auto;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-surface-muted);
+  min-height: 1rem;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.55),
+    transparent
+  );
+  animation: shimmer 1.6s infinite;
+}
+
+.skeleton--text {
+  width: 100%;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/webapp/src/pages/BankLines.tsx
+++ b/webapp/src/pages/BankLines.tsx
@@ -1,58 +1,130 @@
-﻿import './BankLines.css';
+import { useEffect, useState } from 'react';
+import './BankLines.css';
+import { getConnections, isAbortError } from '../lib/api';
+import type { Connection, ConnectionStatus } from '../lib/types';
 
-type LineStatus = 'Active' | 'Pending' | 'Monitoring';
-
-type BankLine = {
-  bank: string;
-  limit: string;
-  utilization: string;
-  status: LineStatus;
-  updated: string;
-  notes: string;
+type AsyncState<T> = {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  data: T;
+  error?: string;
 };
 
-const bankLines: BankLine[] = [
-  {
-    bank: 'Commonwealth Bank',
-    limit: '$1.2B',
-    utilization: '64%',
-    status: 'Active',
-    updated: 'Today 10:24',
-    notes: 'Term sheet expansion approved for Helios storage facility.'
-  },
-  {
-    bank: 'Northwind Credit Union',
-    limit: '$820M',
-    utilization: '71%',
-    status: 'Monitoring',
-    updated: 'Yesterday',
-    notes: 'Utilization trending upward ahead of portfolio rebalance.'
-  },
-  {
-    bank: 'First Harbor Partners',
-    limit: '$640M',
-    utilization: '48%',
-    status: 'Pending',
-    updated: '2 days ago',
-    notes: 'Awaiting revised covenants from legal after counterparty feedback.'
-  }
-];
-
-const statusLabels: Record<LineStatus, string> = {
+const statusLabels: Record<ConnectionStatus, string> = {
   Active: 'Operational',
   Pending: 'Requires approval',
   Monitoring: 'Watch closely'
 };
 
 export default function BankLinesPage() {
+  const [connectionsState, setConnectionsState] = useState<AsyncState<Connection[]>>({
+    status: 'idle',
+    data: [],
+    error: undefined
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setConnectionsState((prev) => ({ ...prev, status: 'loading', error: undefined }));
+
+    getConnections({ signal: controller.signal })
+      .then((data) => {
+        setConnectionsState({ status: 'success', data, error: undefined });
+      })
+      .catch((error) => {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setConnectionsState({
+          status: 'error',
+          data: [],
+          error: 'We were unable to load your bank line data.'
+        });
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  const renderTableBody = () => {
+    if (connectionsState.status === 'loading' || connectionsState.status === 'idle') {
+      return (
+        <tbody>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <tr key={`connection-skeleton-${index}`}>
+              <td colSpan={6}>
+                <div className="skeleton skeleton--text" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      );
+    }
+
+    if (connectionsState.status === 'error') {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={6} className="bank-lines__message" role="alert">
+              <h2>Unable to load bank line visibility</h2>
+              <p>{connectionsState.error}</p>
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    if (!connectionsState.data.length) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={6} className="bank-lines__message">
+              <h2>No bank lines connected yet</h2>
+              <p>
+                Connect a treasury data source to surface utilization, covenants, and watchlist signals for your
+                institutional lenders.
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    return (
+      <tbody>
+        {connectionsState.data.map((line) => (
+          <tr key={line.id}>
+            <th scope="row">{line.bank}</th>
+            <td>{line.limit}</td>
+            <td>
+              <div className="bank-lines__utilization">
+                <span>{line.utilization}</span>
+                <div className="bank-lines__utilization-track" aria-hidden="true">
+                  <div className="bank-lines__utilization-fill" style={{ width: line.utilization }} />
+                </div>
+              </div>
+            </td>
+            <td>
+              <span className={`status-badge status-badge--${line.status.toLowerCase()}`}>
+                <span className="status-badge__label">{line.status}</span>
+                <span className="status-badge__hint">{statusLabels[line.status]}</span>
+              </span>
+            </td>
+            <td>{line.updated}</td>
+            <td>{line.notes}</td>
+          </tr>
+        ))}
+      </tbody>
+    );
+  };
+
   return (
     <div className="bank-lines">
       <header className="bank-lines__header">
         <div>
           <h1>Bank line visibility</h1>
           <p>
-            Stay ahead of liquidity requirements with a consolidated view of commitments, live
-            utilization, and watchlist signals across your institutional lenders.
+            Stay ahead of liquidity requirements with a consolidated view of commitments, live utilization, and watchlist
+            signals across your institutional lenders.
           </p>
         </div>
         <button type="button" className="bank-lines__cta">
@@ -73,33 +145,7 @@ export default function BankLinesPage() {
               <th scope="col">Notes</th>
             </tr>
           </thead>
-          <tbody>
-            {bankLines.map((line) => (
-              <tr key={line.bank}>
-                <th scope="row">{line.bank}</th>
-                <td>{line.limit}</td>
-                <td>
-                  <div className="bank-lines__utilization">
-                    <span>{line.utilization}</span>
-                    <div className="bank-lines__utilization-track" aria-hidden="true">
-                      <div
-                        className="bank-lines__utilization-fill"
-                        style={{ width: line.utilization }}
-                      />
-                    </div>
-                  </div>
-                </td>
-                <td>
-                  <span className={`status-badge status-badge--${line.status.toLowerCase()}`}>
-                    <span className="status-badge__label">{line.status}</span>
-                    <span className="status-badge__hint">{statusLabels[line.status]}</span>
-                  </span>
-                </td>
-                <td>{line.updated}</td>
-                <td>{line.notes}</td>
-              </tr>
-            ))}
-          </tbody>
+          {renderTableBody()}
         </table>
       </div>
     </div>

--- a/webapp/src/pages/Home.css
+++ b/webapp/src/pages/Home.css
@@ -37,20 +37,79 @@
   box-shadow: var(--shadow-sm);
 }
 
+.metric-card--gst {
+  gap: var(--spacing-sm);
+}
+
+.metric-card--loading {
+  position: relative;
+  overflow: hidden;
+}
+
+.metric-card--message {
+  gap: var(--spacing-sm);
+}
+
 .metric-card__header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+  gap: var(--spacing-md);
 }
 
-.metric-card__change {
+.metric-card__header--stacked {
+  align-items: flex-start;
+}
+
+.metric-card__entity {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.metric-card__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-pill);
+  padding: var(--spacing-3xs) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  background-color: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  text-transform: none;
+  letter-spacing: normal;
+  white-space: nowrap;
+}
+
+.metric-card__pill--variance {
+  font-size: var(--font-size-sm);
+}
+
+.metric-card__pill--increase {
+  background-color: rgba(185, 115, 24, 0.18);
+  color: var(--color-warning);
+}
+
+.metric-card__pill--decrease {
+  background-color: rgba(10, 125, 87, 0.16);
+  color: var(--color-success);
+}
+
+.metric-card__pill--status-due-soon {
+  background-color: rgba(185, 115, 24, 0.18);
+  color: var(--color-warning);
+}
+
+.metric-card__pill--status-monitoring {
   background-color: var(--color-primary-soft);
   color: var(--color-primary);
-  padding: var(--spacing-3xs) var(--spacing-sm);
-  font-weight: var(--font-weight-medium);
+}
+
+.metric-card__pill--status-paid {
+  background-color: rgba(10, 125, 87, 0.16);
+  color: var(--color-success);
 }
 
 .metric-card__value {
@@ -58,9 +117,100 @@
   letter-spacing: -0.04em;
 }
 
+.metric-card__change {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium);
+}
+
 .metric-card__description {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+}
+
+.metric-card__footnote {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.queue {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.queue__header {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.queue__subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.queue__table-wrapper {
+  overflow-x: auto;
+}
+
+.queue table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.queue thead {
+  background-color: var(--color-surface-muted);
+}
+
+.queue th,
+.queue td {
+  text-align: left;
+  padding: var(--spacing-md) var(--spacing-lg);
+  font-size: var(--font-size-sm);
+}
+
+.queue tbody tr + tr {
+  border-top: 1px solid var(--color-border);
+}
+
+.queue__status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  padding: var(--spacing-3xs) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+}
+
+.queue__status--queued {
+  background-color: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.queue__status--processing {
+  background-color: rgba(0, 90, 214, 0.18);
+  color: var(--color-primary);
+}
+
+.queue__status--requires-attention {
+  background-color: rgba(185, 115, 24, 0.18);
+  color: var(--color-warning);
+}
+
+.queue__message {
+  text-align: center;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  color: var(--color-text-muted);
+}
+
+.queue__message h3 {
+  margin-bottom: var(--spacing-xs);
+  color: var(--color-text);
 }
 
 .activity {
@@ -95,7 +245,17 @@
   display: flex;
   justify-content: space-between;
   gap: var(--spacing-lg);
-  align-items: baseline;
+  align-items: flex-start;
+}
+
+.activity__item--loading {
+  align-items: stretch;
+}
+
+.activity__skeleton {
+  display: grid;
+  gap: var(--spacing-2xs);
+  width: min(18rem, 100%);
 }
 
 .activity__name {
@@ -107,15 +267,101 @@
   color: var(--color-text-muted);
 }
 
-.activity__status {
+.activity__meta {
+  display: grid;
+  justify-items: end;
+  gap: var(--spacing-3xs);
+  min-width: 12rem;
+}
+
+.activity__actor {
   font-size: var(--font-size-sm);
-  color: var(--color-primary);
   font-weight: var(--font-weight-medium);
+}
+
+.activity__timestamp {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.activity__message {
+  background-color: var(--color-surface-muted);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-2xs);
+}
+
+.activity__message h3 {
+  font-size: var(--font-size-md);
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-surface-muted);
+  min-height: 0.75rem;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.55),
+    transparent
+  );
+  animation: shimmer 1.6s infinite;
+}
+
+.skeleton--heading {
+  min-height: 1.2rem;
+  width: 80%;
+}
+
+.skeleton--text {
+  min-height: 0.75rem;
+  width: 100%;
+}
+
+.skeleton--short {
+  width: 60%;
+}
+
+.skeleton--pill {
+  border-radius: var(--radius-pill);
+  min-height: 1.2rem;
+  width: 6.5rem;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 @media (max-width: 700px) {
   .activity__item {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .activity__meta {
+    justify-items: flex-start;
   }
 }

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,85 +1,395 @@
-﻿import './Home.css';
+import { useEffect, useState } from 'react';
+import './Home.css';
+import {
+  getAuditTrail,
+  getGstVariance,
+  getObligations,
+  getPaygwQueue,
+  isAbortError
+} from '../lib/api';
+import type {
+  AuditTrailItem,
+  GstVariance,
+  Obligation,
+  PaygwQueueItem
+} from '../lib/types';
 
-const metrics = [
-  {
-    title: 'Active mandates',
-    value: '24',
-    change: '+3.4% vs last week',
-    description:
-      'Structured credit and private equity deals currently tracked in the Pro+ workspace.'
-  },
-  {
-    title: 'Total committed capital',
-    value: '$4.8B',
-    change: '+$180M new commitments',
-    description: 'Aggregate bank and fund lines allocated across open portfolios.'
-  },
-  {
-    title: 'Average utilization',
-    value: '67%',
-    change: '-5.3% risk exposure',
-    description: 'Weighted utilization across all active bank lines for the current quarter.'
-  }
-];
+type AsyncState<T> = {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  data: T;
+  error?: string;
+};
 
-const activities = [
-  {
-    name: 'GreenRidge solar expansion',
-    detail: 'Closing diligence with Commonwealth Bank',
-    status: 'Due tomorrow'
-  },
-  {
-    name: 'Helios storage facility',
-    detail: 'Amended terms shared with syndicate partners',
-    status: 'Updated 2h ago'
-  },
-  {
-    name: 'Urban mobility fund II',
-    detail: 'Capital call scheduled for Monday',
-    status: 'Action needed'
-  }
-];
+function createInitialState<T>(data: T): AsyncState<T> {
+  return {
+    status: 'idle',
+    data,
+    error: undefined
+  };
+}
+
+function toStatusClass(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, '-');
+}
 
 export default function HomePage() {
+  const [obligationsState, setObligationsState] = useState<AsyncState<Obligation[]>>(
+    createInitialState<Obligation[]>([])
+  );
+  const [queueState, setQueueState] = useState<AsyncState<PaygwQueueItem[]>>(
+    createInitialState<PaygwQueueItem[]>([])
+  );
+  const [gstState, setGstState] = useState<AsyncState<GstVariance | null>>(
+    createInitialState<GstVariance | null>(null)
+  );
+  const [auditState, setAuditState] = useState<AsyncState<AuditTrailItem[]>>(
+    createInitialState<AuditTrailItem[]>([])
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setObligationsState((prev) => ({ ...prev, status: 'loading', error: undefined }));
+
+    getObligations({ signal: controller.signal })
+      .then((data) => {
+        setObligationsState({ status: 'success', data, error: undefined });
+      })
+      .catch((error) => {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setObligationsState({
+          status: 'error',
+          data: [],
+          error: 'Unable to load upcoming obligations right now.'
+        });
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setQueueState((prev) => ({ ...prev, status: 'loading', error: undefined }));
+
+    getPaygwQueue({ signal: controller.signal })
+      .then((data) => {
+        setQueueState({ status: 'success', data, error: undefined });
+      })
+      .catch((error) => {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setQueueState({
+          status: 'error',
+          data: [],
+          error: 'We could not fetch the PAYGW queue. Please try again.'
+        });
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setGstState((prev) => ({ ...prev, status: 'loading', error: undefined }));
+
+    getGstVariance({ signal: controller.signal })
+      .then((data) => {
+        setGstState({ status: 'success', data, error: undefined });
+      })
+      .catch((error) => {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setGstState({
+          status: 'error',
+          data: null,
+          error: 'GST variance insights are temporarily unavailable.'
+        });
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setAuditState((prev) => ({ ...prev, status: 'loading', error: undefined }));
+
+    getAuditTrail({ signal: controller.signal })
+      .then((data) => {
+        setAuditState({ status: 'success', data, error: undefined });
+      })
+      .catch((error) => {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        setAuditState({
+          status: 'error',
+          data: [],
+          error: 'We could not retrieve the audit trail feed.'
+        });
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  const renderObligationCards = () => {
+    if (obligationsState.status === 'loading' || obligationsState.status === 'idle') {
+      return Array.from({ length: 3 }).map((_, index) => (
+        <article key={`obligation-skeleton-${index}`} className="metric-card metric-card--loading" aria-hidden>
+          <div className="skeleton skeleton--pill" />
+          <div className="skeleton skeleton--heading" />
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text skeleton--short" />
+        </article>
+      ));
+    }
+
+    if (obligationsState.status === 'error') {
+      return (
+        <article className="metric-card metric-card--message" role="alert">
+          <h2>Unable to load obligations</h2>
+          <p>{obligationsState.error}</p>
+        </article>
+      );
+    }
+
+    if (!obligationsState.data.length) {
+      return (
+        <article className="metric-card metric-card--message">
+          <h2>You're all caught up</h2>
+          <p>All payroll and tax obligations are reconciled. New items will surface here automatically.</p>
+        </article>
+      );
+    }
+
+    return obligationsState.data.map((obligation) => (
+      <article key={obligation.id} className="metric-card">
+        <header className="metric-card__header">
+          <h2>{obligation.name}</h2>
+          <span className={`metric-card__pill metric-card__pill--status-${toStatusClass(obligation.status)}`}>
+            {obligation.status}
+          </span>
+        </header>
+        <p className="metric-card__value">{obligation.amount}</p>
+        <p className="metric-card__change">{obligation.dueDate}</p>
+        <p className="metric-card__description">{obligation.commentary}</p>
+      </article>
+    ));
+  };
+
+  const renderGstVarianceCard = () => {
+    if (gstState.status === 'loading' || gstState.status === 'idle') {
+      return (
+        <article className="metric-card metric-card--loading" aria-hidden>
+          <div className="skeleton skeleton--pill" />
+          <div className="skeleton skeleton--heading" />
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text skeleton--short" />
+        </article>
+      );
+    }
+
+    if (gstState.status === 'error') {
+      return (
+        <article className="metric-card metric-card--message" role="alert">
+          <h2>GST variance unavailable</h2>
+          <p>{gstState.error}</p>
+        </article>
+      );
+    }
+
+    if (!gstState.data) {
+      return (
+        <article className="metric-card metric-card--message">
+          <h2>No GST variance flagged</h2>
+          <p>Variance alerts will appear here once we detect movement outside configured thresholds.</p>
+        </article>
+      );
+    }
+
+    const { variance, direction, entity, narrative, updated } = gstState.data;
+    const formattedVariance = `${direction === 'Increase' ? '+' : '−'}${variance.toFixed(1)}%`;
+
+    return (
+      <article className="metric-card metric-card--gst">
+        <header className="metric-card__header metric-card__header--stacked">
+          <div>
+            <h2>GST variance</h2>
+            <p className="metric-card__entity">{entity}</p>
+          </div>
+          <span
+            className={`metric-card__pill metric-card__pill--variance metric-card__pill--${direction === 'Increase' ? 'increase' : 'decrease'}`}
+          >
+            {formattedVariance}
+          </span>
+        </header>
+        <p className="metric-card__description">{narrative}</p>
+        <p className="metric-card__footnote">{updated}</p>
+      </article>
+    );
+  };
+
+  const renderQueueTableBody = () => {
+    if (queueState.status === 'loading' || queueState.status === 'idle') {
+      return (
+        <tbody>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <tr key={`queue-skeleton-${index}`}>
+              <td colSpan={5}>
+                <div className="skeleton skeleton--text" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      );
+    }
+
+    if (queueState.status === 'error') {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={5} className="queue__message" role="alert">
+              <h3>We couldn't load the PAYGW queue</h3>
+              <p>{queueState.error}</p>
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    if (!queueState.data.length) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={5} className="queue__message">
+              <h3>No filings waiting</h3>
+              <p>Great news—there are no PAYGW submissions pending. New filings will show up here automatically.</p>
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    return (
+      <tbody>
+        {queueState.data.map((item) => (
+          <tr key={item.id}>
+            <th scope="row">{item.employer}</th>
+            <td>{item.amount}</td>
+            <td>{item.payPeriod}</td>
+            <td>
+              <span className={`queue__status queue__status--${toStatusClass(item.status)}`}>
+                {item.status}
+              </span>
+            </td>
+            <td>{item.nextAction}</td>
+          </tr>
+        ))}
+      </tbody>
+    );
+  };
+
+  const renderAuditTrail = () => {
+    if (auditState.status === 'loading' || auditState.status === 'idle') {
+      return (
+        <ul className="activity__list">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <li key={`audit-skeleton-${index}`} className="activity__item activity__item--loading" aria-hidden>
+              <div className="activity__skeleton">
+                <div className="skeleton skeleton--text" />
+                <div className="skeleton skeleton--text skeleton--short" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    if (auditState.status === 'error') {
+      return (
+        <div className="activity__message" role="alert">
+          <h3>Unable to load audit trail</h3>
+          <p>{auditState.error}</p>
+        </div>
+      );
+    }
+
+    if (!auditState.data.length) {
+      return (
+        <div className="activity__message">
+          <h3>No activity yet</h3>
+          <p>When your team lodges payroll or GST updates, we'll capture the approvals and submissions right here.</p>
+        </div>
+      );
+    }
+
+    return (
+      <ul className="activity__list">
+        {auditState.data.map((item) => (
+          <li key={item.id} className="activity__item">
+            <div>
+              <p className="activity__name">{item.action}</p>
+              <p className="activity__detail">{item.context}</p>
+            </div>
+            <div className="activity__meta">
+              <span className="activity__actor">{item.actor}</span>
+              <span className="activity__timestamp">{item.timestamp}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
   return (
     <div className="page">
       <header className="page__header">
         <h1>Portfolio pulse</h1>
         <p>
-          Monitor capital utilization, track live mandates, and surface emerging risk signals
-          across your institutional banking relationships.
+          Monitor capital utilization, track live mandates, and surface emerging risk signals across your institutional
+          banking relationships.
         </p>
       </header>
 
-      <section aria-label="Key metrics" className="metric-grid">
-        {metrics.map((metric) => (
-          <article className="metric-card" key={metric.title}>
-            <header className="metric-card__header">
-              <h2>{metric.title}</h2>
-              <span className="metric-card__change">{metric.change}</span>
-            </header>
-            <p className="metric-card__value">{metric.value}</p>
-            <p className="metric-card__description">{metric.description}</p>
-          </article>
-        ))}
+      <section aria-label="Compliance summary" className="metric-grid">
+        {renderObligationCards()}
+        {renderGstVarianceCard()}
       </section>
 
-      <section aria-label="Latest activity" className="activity">
-        <div className="activity__header">
-          <h2>Workflow alerts</h2>
-          <p className="activity__subtitle">Curated tasks across deal teams and syndicate partners</p>
+      <section aria-label="PAYGW filing queue" className="queue">
+        <div className="queue__header">
+          <h2>PAYGW filing queue</h2>
+          <p className="queue__subtitle">Stay ahead of payroll withholding deadlines across every operating entity.</p>
         </div>
-        <ul className="activity__list">
-          {activities.map((activity) => (
-            <li className="activity__item" key={activity.name}>
-              <div>
-                <p className="activity__name">{activity.name}</p>
-                <p className="activity__detail">{activity.detail}</p>
-              </div>
-              <span className="activity__status">{activity.status}</span>
-            </li>
-          ))}
-        </ul>
+        <div className="queue__table-wrapper">
+          <table>
+            <caption className="sr-only">Upcoming PAYGW filings and their current status</caption>
+            <thead>
+              <tr>
+                <th scope="col">Employer</th>
+                <th scope="col">Amount</th>
+                <th scope="col">Pay period</th>
+                <th scope="col">Status</th>
+                <th scope="col">Next step</th>
+              </tr>
+            </thead>
+            {renderQueueTableBody()}
+          </table>
+        </div>
+      </section>
+
+      <section aria-label="Audit trail" className="activity">
+        <div className="activity__header">
+          <h2>Audit trail</h2>
+          <p className="activity__subtitle">Latest submissions and approvals across your compliance workflows.</p>
+        </div>
+        {renderAuditTrail()}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a reusable lib/api layer that returns mocked obligations, PAYGW queue, GST variance, audit trail, and connection data
- refactor the home dashboard to fetch mocked data with abort-safe effects plus loading, empty, and error UI states
- update the bank lines page to consume the mocked connections feed and render skeletons and friendly fallback messaging

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f7690c2ba883279dc576af5edd446e