### PR TITLE
Add security monitoring dashboard

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import HomePage from './pages/Home';
 import BankLinesPage from './pages/BankLines';
+import SecurityPage from './pages/Security';
 import './App.css';
 
 type Theme = 'light' | 'dark';
@@ -47,6 +48,9 @@ export default function App() {
           <NavLink className="app__nav-link" to="/bank-lines">
             Bank lines
           </NavLink>
+          <NavLink className="app__nav-link" to="/security">
+            Security
+          </NavLink>
         </nav>
         <button
           type="button"
@@ -61,6 +65,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/bank-lines" element={<BankLinesPage />} />
+          <Route path="/security" element={<SecurityPage />} />
         </Routes>
       </main>
       <footer className="app__footer">

--- a/webapp/src/pages/Security.css
+++ b/webapp/src/pages/Security.css
@@ -1,0 +1,282 @@
+.security-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xl);
+  padding-top: var(--spacing-2xl);
+}
+
+.security-page__header {
+  display: grid;
+  gap: var(--spacing-sm);
+  max-width: 48rem;
+}
+
+.security-page__header h1 {
+  font-size: var(--font-size-2xl);
+  letter-spacing: -0.03em;
+}
+
+.security-page__header p {
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
+}
+
+.security-section {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.security-section__header {
+  display: grid;
+  gap: var(--spacing-2xs);
+}
+
+.security-section__header p {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.security-connections {
+  display: grid;
+  gap: var(--spacing-lg);
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.security-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-md);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-muted) 100%);
+}
+
+.security-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-lg);
+}
+
+.security-card__summary {
+  display: grid;
+  gap: var(--spacing-2xs);
+}
+
+.security-card__header h3 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.security-card__header p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+  padding: var(--spacing-3xs) var(--spacing-sm);
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background-color: var(--color-surface);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.1;
+}
+
+.status-badge__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+}
+
+.status-badge__hint {
+  color: var(--color-text-muted);
+}
+
+.status-badge--positive {
+  border-color: rgba(46, 170, 126, 0.35);
+  background-color: rgba(46, 170, 126, 0.12);
+  color: #1c7c56;
+}
+
+.status-badge--positive .status-badge__dot {
+  background-color: #2eaa7e;
+}
+
+.status-badge--caution {
+  border-color: rgba(253, 176, 34, 0.38);
+  background-color: rgba(253, 214, 34, 0.18);
+  color: #8d6100;
+}
+
+.status-badge--caution .status-badge__dot {
+  background-color: #fdb022;
+}
+
+.status-badge--neutral {
+  border-color: rgba(80, 99, 125, 0.28);
+  background-color: rgba(80, 99, 125, 0.12);
+  color: #3a4d66;
+}
+
+.status-badge--neutral .status-badge__dot {
+  background-color: #50637d;
+}
+
+.security-anomalies {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.security-anomalies__item {
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) 3fr auto;
+  gap: var(--spacing-lg);
+  align-items: center;
+  padding: var(--spacing-md) 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.security-anomalies__item:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.security-anomalies__time {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.security-anomalies__source {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+}
+
+.security-anomalies__description {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.severity-badge {
+  border-radius: var(--radius-pill);
+  padding: var(--spacing-3xs) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.severity-badge--critical {
+  background-color: rgba(220, 38, 38, 0.12);
+  color: #be123c;
+}
+
+.severity-badge--warning {
+  background-color: rgba(234, 179, 8, 0.15);
+  color: #854d0e;
+}
+
+.severity-badge--calm {
+  background-color: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.security-thresholds {
+  display: grid;
+  gap: var(--spacing-lg);
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.security-thresholds__control {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.security-thresholds__control label {
+  font-weight: var(--font-weight-medium);
+}
+
+.security-thresholds__input {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.security-thresholds__value {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  min-width: 5rem;
+}
+
+.security-thresholds__help {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.security-thresholds input[type='range'],
+.security-thresholds input[type='number'] {
+  flex: 1;
+  min-width: 0;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-2xs) var(--spacing-xs);
+  background-color: var(--color-surface);
+}
+
+.security-thresholds input[type='number'] {
+  max-width: 10rem;
+}
+
+.security-thresholds input[type='range'] {
+  height: 0.45rem;
+  padding: 0;
+}
+
+.security-thresholds input:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.security-thresholds__preview {
+  margin-top: var(--spacing-sm);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-lg);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: var(--font-size-md);
+}
+
+.security-thresholds__preview strong {
+  font-size: var(--font-size-xl);
+}
+
+@media (max-width: 800px) {
+  .security-anomalies__item {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-sm);
+    align-items: flex-start;
+  }
+
+  .security-thresholds__input {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .security-thresholds__value {
+    min-width: auto;
+  }
+}

--- a/webapp/src/pages/Security.tsx
+++ b/webapp/src/pages/Security.tsx
@@ -1,0 +1,237 @@
+import { useId, useMemo, useState } from 'react';
+import './Security.css';
+
+type Connection = {
+  name: string;
+  description: string;
+  status: 'Operational' | 'Attention needed' | 'Connected';
+  tone: 'positive' | 'caution' | 'neutral';
+};
+
+type Anomaly = {
+  id: number;
+  timestamp: string;
+  displayTime: string;
+  source: string;
+  description: string;
+  severity: 'Low' | 'Medium' | 'High';
+};
+
+const connections: Connection[] = [
+  {
+    name: 'Payroll API',
+    description: 'Real-time payroll ledger synchronisation into treasury controls.',
+    status: 'Operational',
+    tone: 'positive'
+  },
+  {
+    name: 'Banking',
+    description: 'Daily settlement files streamed from primary banking custodians.',
+    status: 'Operational',
+    tone: 'positive'
+  },
+  {
+    name: 'POS',
+    description: 'Omnichannel point-of-sale transaction summaries across regions.',
+    status: 'Attention needed',
+    tone: 'caution'
+  },
+  {
+    name: 'ATO',
+    description: 'ATO portal ingest for GST obligations and lodgement confirmations.',
+    status: 'Connected',
+    tone: 'neutral'
+  }
+];
+
+const anomalies: Anomaly[] = [
+  {
+    id: 1,
+    timestamp: '2024-07-22T13:04:00Z',
+    displayTime: 'Jul 22, 13:04',
+    source: 'Payroll API',
+    description: 'Surge in manual payroll overrides above variance tolerance.',
+    severity: 'High'
+  },
+  {
+    id: 2,
+    timestamp: '2024-07-22T12:51:00Z',
+    displayTime: 'Jul 22, 12:51',
+    source: 'Banking',
+    description: 'Clearing delay detected on Commonwealth Bank overnight batch.',
+    severity: 'Medium'
+  },
+  {
+    id: 3,
+    timestamp: '2024-07-22T12:37:00Z',
+    displayTime: 'Jul 22, 12:37',
+    source: 'POS',
+    description: 'Higher than expected refunds from APAC omnichannel feeds.',
+    severity: 'Low'
+  }
+];
+
+const severityTone: Record<Anomaly['severity'], 'critical' | 'warning' | 'calm'> = {
+  High: 'critical',
+  Medium: 'warning',
+  Low: 'calm'
+};
+
+function StatusBadge({ label, hint, tone }: { label: string; hint: string; tone: Connection['tone'] }) {
+  return (
+    <span className={`status-badge status-badge--${tone}`}>
+      <span className="status-badge__dot" aria-hidden="true" />
+      <span className="status-badge__label">{label}</span>
+      <span className="status-badge__hint">{hint}</span>
+    </span>
+  );
+}
+
+function SeverityBadge({ label }: { label: Anomaly['severity'] }) {
+  const tone = severityTone[label];
+  return <span className={`severity-badge severity-badge--${tone}`}>{label}</span>;
+}
+
+export default function SecurityPage() {
+  const [varianceThreshold, setVarianceThreshold] = useState(12);
+  const [paymentLimit, setPaymentLimit] = useState(250000);
+  const [alertFrequency, setAlertFrequency] = useState(4);
+
+  const varianceHelpId = useId();
+  const paymentHelpId = useId();
+  const frequencyHelpId = useId();
+
+  const projectedAlerts = useMemo(() => {
+    const varianceFactor = varianceThreshold * 1.4;
+    const limitFactor = paymentLimit / 60000;
+    const cadenceFactor = 12 - alertFrequency * 1.5;
+    return Math.max(1, Math.round(varianceFactor + limitFactor + cadenceFactor));
+  }, [varianceThreshold, paymentLimit, alertFrequency]);
+
+  return (
+    <div className="security-page">
+      <header className="security-page__header">
+        <h1>Security &amp; fraud watch</h1>
+        <p>
+          Keep integration health, anomaly triage, and automated thresholds aligned so your
+          capital workflows stay protected without slowing operations.
+        </p>
+      </header>
+
+      <section aria-label="Connections" className="security-section">
+        <div className="security-section__header">
+          <h2>Connections</h2>
+          <p>Integration status across critical data feeds.</p>
+        </div>
+        <div className="security-connections">
+          {connections.map((connection) => (
+            <article className="security-card" key={connection.name}>
+              <header className="security-card__header">
+                <div className="security-card__summary">
+                  <h3>{connection.name}</h3>
+                  <p>{connection.description}</p>
+                </div>
+                <StatusBadge label={connection.status} hint="Synced 5m ago" tone={connection.tone} />
+              </header>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-label="Anomalies" className="security-section">
+        <div className="security-section__header">
+          <h2>Anomalies</h2>
+          <p>Live feed of detection events across integrations.</p>
+        </div>
+        <ul className="security-anomalies">
+          {anomalies.map((anomaly) => (
+            <li className="security-anomalies__item" key={anomaly.id}>
+              <time dateTime={anomaly.timestamp} className="security-anomalies__time">
+                {anomaly.displayTime}
+              </time>
+              <div className="security-anomalies__detail">
+                <p className="security-anomalies__source">{anomaly.source}</p>
+                <p className="security-anomalies__description">{anomaly.description}</p>
+              </div>
+              <SeverityBadge label={anomaly.severity} />
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-label="Thresholds" className="security-section">
+        <div className="security-section__header">
+          <h2>Thresholds</h2>
+          <p>Adjust automated guardrails for fraud and operational risk alerts.</p>
+        </div>
+        <form className="security-thresholds">
+          <div className="security-thresholds__control">
+            <label htmlFor="variance">Cash variance tolerance</label>
+            <div className="security-thresholds__input">
+              <input
+                id="variance"
+                type="range"
+                min={0}
+                max={25}
+                value={varianceThreshold}
+                onChange={(event) => setVarianceThreshold(Number(event.target.value))}
+                aria-describedby={varianceHelpId}
+              />
+              <span className="security-thresholds__value">{varianceThreshold}%</span>
+            </div>
+            <p id={varianceHelpId} className="security-thresholds__help">
+              Trigger anomaly reviews when variance exceeds the selected percentage window.
+            </p>
+          </div>
+
+          <div className="security-thresholds__control">
+            <label htmlFor="payment-limit">Single payment limit</label>
+            <div className="security-thresholds__input">
+              <input
+                id="payment-limit"
+                type="number"
+                min={50000}
+                step={5000}
+                value={paymentLimit}
+                onChange={(event) =>
+                  setPaymentLimit(event.target.value === '' ? 0 : Number(event.target.value))
+                }
+                aria-describedby={paymentHelpId}
+              />
+              <span className="security-thresholds__value">
+                ${paymentLimit.toLocaleString()}
+              </span>
+            </div>
+            <p id={paymentHelpId} className="security-thresholds__help">
+              Block payments exceeding this ceiling for manual secondary approval.
+            </p>
+          </div>
+
+          <div className="security-thresholds__control">
+            <label htmlFor="alert-frequency">Alert digest cadence</label>
+            <div className="security-thresholds__input">
+              <input
+                id="alert-frequency"
+                type="range"
+                min={1}
+                max={8}
+                value={alertFrequency}
+                onChange={(event) => setAlertFrequency(Number(event.target.value))}
+                aria-describedby={frequencyHelpId}
+              />
+              <span className="security-thresholds__value">Every {alertFrequency}h</span>
+            </div>
+            <p id={frequencyHelpId} className="security-thresholds__help">
+              Control how frequently consolidated fraud digests are distributed to teams.
+            </p>
+          </div>
+        </form>
+
+        <div className="security-thresholds__preview" aria-live="polite">
+          <p>Projected daily review load</p>
+          <strong>{projectedAlerts} cases</strong>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Security & Fraud Watch page with integration cards, anomaly feed, and adjustable thresholds
- implement supporting styles including focus-visible outlines and status/severity badges
- register the page with the application shell navigation and routing

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f768fa2c588327be7dbef7b1c24c36