### PR TITLE
feat(webapp): add GST reconciliation heatmap workflow

### DIFF
--- a/webapp/src/pages/GST.css
+++ b/webapp/src/pages/GST.css
@@ -1,0 +1,267 @@
+.gst-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.gst-page__header {
+  max-width: 60ch;
+}
+
+.gst-page__header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.gst-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.gst-card__header h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.gst-card__header p {
+  color: #475569;
+  margin: 0;
+}
+
+.gst-heatmap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.gst-heatmap__columns {
+  display: grid;
+  grid-template-columns: 120px repeat(7, minmax(44px, 1fr));
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.gst-heatmap__corner {
+  display: block;
+}
+
+.gst-heatmap__row {
+  display: grid;
+  grid-template-columns: 120px repeat(7, minmax(44px, 1fr));
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.gst-heatmap__row-label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.gst-heatmap__cell {
+  min-width: 48px;
+  min-height: 48px;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #0f172a;
+  outline: none;
+  position: relative;
+}
+
+.gst-heatmap__cell:focus-visible {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.6);
+}
+
+.gst-heatmap__cell[aria-selected='true'] {
+  box-shadow: inset 0 0 0 2px #1d4ed8;
+}
+
+.gst-heatmap__value {
+  position: relative;
+  z-index: 1;
+}
+
+.gst-heatmap__cell--low {
+  background: #bae6fd;
+  background-image: radial-gradient(circle at 8px 8px, #0f172a 10%, transparent 11%),
+    radial-gradient(circle at 24px 24px, #0f172a 10%, transparent 11%);
+  background-size: 32px 32px;
+}
+
+.gst-heatmap__cell--medium {
+  background: #fdba74;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(15, 23, 42, 0.65),
+    rgba(15, 23, 42, 0.65) 6px,
+    transparent 6px,
+    transparent 12px
+  );
+}
+
+.gst-heatmap__cell--high {
+  background: #fecdd3;
+  background-image: linear-gradient(45deg, rgba(15, 23, 42, 0.65) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(15, 23, 42, 0.65) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(15, 23, 42, 0.65) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(15, 23, 42, 0.65) 75%);
+  background-size: 24px 24px;
+  background-position: 0 0, 0 12px, 12px -12px, -12px 0px;
+}
+
+.gst-heatmap__legend h3 {
+  margin-bottom: 0.5rem;
+}
+
+.gst-heatmap__legend ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.gst-heatmap__legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #334155;
+}
+
+.gst-heatmap__legend-swatch {
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.25);
+}
+
+.gst-stepper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.gst-stepper__status {
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.gst-stepper__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.gst-stepper__item {
+  border-left: 3px solid #cbd5f5;
+  padding-left: 1rem;
+}
+
+.gst-stepper__trigger {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.75rem;
+  align-items: baseline;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  color: #0f172a;
+  font: inherit;
+}
+
+.gst-stepper__trigger:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 4px;
+}
+
+.gst-stepper__trigger--active {
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.gst-stepper__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.gst-stepper__content {
+  margin-top: 0.5rem;
+  color: #475569;
+}
+
+.gst-stepper__controls {
+  display: flex;
+  gap: 1rem;
+}
+
+.gst-stepper__controls button {
+  background: #1d4ed8;
+  border: none;
+  color: #ffffff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.gst-stepper__controls button[disabled] {
+  background: #cbd5f5;
+  color: #475569;
+  cursor: not-allowed;
+}
+
+.gst-stepper__controls button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .gst-heatmap__columns,
+  .gst-heatmap__row {
+    grid-template-columns: 100px repeat(7, minmax(44px, 1fr));
+  }
+
+  .gst-heatmap__cell {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .gst-stepper__controls {
+    flex-direction: column;
+  }
+
+  .gst-stepper__controls button {
+    width: 100%;
+  }
+}
+
+/* Visually hidden utility for potential reuse */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/webapp/src/pages/GST.tsx
+++ b/webapp/src/pages/GST.tsx
@@ -1,0 +1,233 @@
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import './GST.css';
+
+const columnLabels = [
+  'Outlet 1',
+  'Outlet 2',
+  'Outlet 3',
+  'Outlet 4',
+  'Outlet 5',
+  'Outlet 6',
+  'Outlet 7'
+];
+
+const rowLabels = [
+  'Week 1',
+  'Week 2',
+  'Week 3',
+  'Week 4',
+  'Week 5'
+];
+
+const heatmapValues: number[][] = [
+  [2, 4, 7, 5, 9, 3, 1],
+  [5, 6, 8, 7, 4, 2, 3],
+  [3, 2, 4, 6, 8, 7, 5],
+  [4, 5, 6, 8, 7, 5, 2],
+  [1, 3, 5, 4, 6, 8, 9]
+];
+
+function getVarianceCategory(value: number) {
+  if (value >= 7) return 'high';
+  if (value >= 4) return 'medium';
+  return 'low';
+}
+
+export default function GSTPage() {
+  const [selectedRow, setSelectedRow] = useState(0);
+  const [selectedCol, setSelectedCol] = useState(0);
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const cellRefs = useRef<(HTMLDivElement | null)[][]>(
+    heatmapValues.map((row) => row.map(() => null))
+  );
+
+  useEffect(() => {
+    const cell = cellRefs.current[selectedRow]?.[selectedCol];
+    cell?.focus();
+  }, [selectedRow, selectedCol]);
+
+  const steps = useMemo(
+    () => [
+      {
+        title: 'Reconcile GST collected',
+        description:
+          'Validate point-of-sale GST totals against ledger postings for the reporting period.'
+      },
+      {
+        title: 'Investigate transaction variance',
+        description:
+          'Drill into mismatched receipts and journals to confirm tax codes and adjustments.'
+      },
+      {
+        title: 'Document resolution and adjustments',
+        description:
+          'Record findings, apply ledger corrections, and prepare the BAS reconciliation notes.'
+      }
+    ],
+    []
+  );
+
+  const handleCellSelection = (rowIndex: number, colIndex: number) => {
+    setSelectedRow(rowIndex);
+    setSelectedCol(colIndex);
+  };
+
+  const handleCellKeyDown = (event: KeyboardEvent<HTMLDivElement>, rowIndex: number, colIndex: number) => {
+    let newRow = rowIndex;
+    let newCol = colIndex;
+
+    switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault();
+        newRow = Math.max(0, rowIndex - 1);
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        newRow = Math.min(heatmapValues.length - 1, rowIndex + 1);
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        newCol = Math.max(0, colIndex - 1);
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        newCol = Math.min(heatmapValues[0].length - 1, colIndex + 1);
+        break;
+      default:
+        return;
+    }
+
+    handleCellSelection(newRow, newCol);
+  };
+
+  const goToStep = (index: number) => {
+    setCurrentStep(index);
+  };
+
+  const goToNextStep = () => {
+    setCurrentStep((prev) => Math.min(prev + 1, steps.length - 1));
+  };
+
+  const goToPreviousStep = () => {
+    setCurrentStep((prev) => Math.max(prev - 1, 0));
+  };
+
+  return (
+    <div className="gst-page">
+      <header className="gst-page__header">
+        <h1>GST variance reconciliation</h1>
+        <p>
+          Compare GST reported in your ledger with point-of-sale collections, quickly identify
+          discrepancies, and track remediation progress for the Business Activity Statement (BAS).
+        </p>
+      </header>
+
+      <section className="gst-card" aria-labelledby="gst-heatmap-heading">
+        <div className="gst-card__header">
+          <h2 id="gst-heatmap-heading">POS vs ledger heatmap</h2>
+          <p>
+            Navigate the grid to review weekly GST variances across key outlets. Use the arrow keys
+            to move between cells and press tab to exit the grid.
+          </p>
+        </div>
+
+        <div className="gst-heatmap" role="grid" aria-rowcount={rowLabels.length} aria-colcount={columnLabels.length}>
+          <div className="gst-heatmap__columns" aria-hidden="true">
+            <span className="gst-heatmap__corner" />
+            {columnLabels.map((label) => (
+              <span key={label}>{label}</span>
+            ))}
+          </div>
+          {heatmapValues.map((row, rowIndex) => (
+            <div className="gst-heatmap__row" role="row" key={rowLabels[rowIndex]} aria-label={rowLabels[rowIndex]}>
+              <span className="gst-heatmap__row-label" role="rowheader">
+                {rowLabels[rowIndex]}
+              </span>
+              {row.map((value, colIndex) => {
+                const isSelected = selectedRow === rowIndex && selectedCol === colIndex;
+                const category = getVarianceCategory(value);
+                return (
+                  <div
+                    key={`${rowIndex}-${colIndex}`}
+                    ref={(el) => {
+                      cellRefs.current[rowIndex][colIndex] = el;
+                    }}
+                    role="gridcell"
+                    tabIndex={isSelected ? 0 : -1}
+                    aria-selected={isSelected}
+                    aria-label={`${rowLabels[rowIndex]}, ${columnLabels[colIndex]}, variance ${value} basis points`}
+                    className={`gst-heatmap__cell gst-heatmap__cell--${category}`}
+                    onClick={() => handleCellSelection(rowIndex, colIndex)}
+                    onKeyDown={(event) => handleCellKeyDown(event, rowIndex, colIndex)}
+                  >
+                    <span className="gst-heatmap__value">{value}</span>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <div className="gst-heatmap__legend" aria-label="Heatmap legend">
+          <h3>Legend</h3>
+          <ul>
+            <li>
+              <span className="gst-heatmap__legend-swatch gst-heatmap__cell--low" aria-hidden="true" />
+              <span>Low variance (0-3 basis points, dotted pattern)</span>
+            </li>
+            <li>
+              <span className="gst-heatmap__legend-swatch gst-heatmap__cell--medium" aria-hidden="true" />
+              <span>Moderate variance (4-6 basis points, striped pattern)</span>
+            </li>
+            <li>
+              <span className="gst-heatmap__legend-swatch gst-heatmap__cell--high" aria-hidden="true" />
+              <span>High variance (7+ basis points, checkered pattern)</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="gst-card" aria-labelledby="gst-stepper-heading">
+        <div className="gst-card__header">
+          <h2 id="gst-stepper-heading">Resolve discrepancy workflow</h2>
+          <p>Track resolution progress across key GST reconciliation tasks.</p>
+        </div>
+
+        <div className="gst-stepper" role="group" aria-labelledby="gst-stepper-heading">
+          <div className="gst-stepper__status" aria-live="polite">
+            {`Current step: ${steps[currentStep].title}`}
+          </div>
+          <ol className="gst-stepper__list">
+            {steps.map((step, index) => (
+              <li key={step.title} className="gst-stepper__item">
+                <button
+                  type="button"
+                  className={`gst-stepper__trigger${index === currentStep ? ' gst-stepper__trigger--active' : ''}`}
+                  aria-current={index === currentStep ? 'step' : undefined}
+                  onClick={() => goToStep(index)}
+                >
+                  <span className="gst-stepper__label">Step {index + 1}</span>
+                  <span className="gst-stepper__title">{step.title}</span>
+                </button>
+                {index === currentStep && (
+                  <div className="gst-stepper__content">
+                    <p>{step.description}</p>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ol>
+          <div className="gst-stepper__controls">
+            <button type="button" onClick={goToPreviousStep} disabled={currentStep === 0}>
+              Previous
+            </button>
+            <button type="button" onClick={goToNextStep} disabled={currentStep === steps.length - 1}>
+              Next
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a GST reconciliation page with an accessible heatmap comparing POS and ledger variance
- introduce patterned legend and keyboard navigation for the 7x5 heatmap grid
- add a three-step GST discrepancy resolution stepper with aria-live announcements

## Testing
- pnpm --filter webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f768d6e61c83279c516ae3565645cb