### PR TITLE
feat: add PAYGW variance remediation workflow

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import HomePage from './pages/Home';
 import BankLinesPage from './pages/BankLines';
+import PAYGWPage from './pages/PAYGW';
 import './App.css';
 
 type Theme = 'light' | 'dark';
@@ -47,6 +48,9 @@ export default function App() {
           <NavLink className="app__nav-link" to="/bank-lines">
             Bank lines
           </NavLink>
+          <NavLink className="app__nav-link" to="/paygw">
+            PAYGW flow
+          </NavLink>
         </nav>
         <button
           type="button"
@@ -61,6 +65,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/bank-lines" element={<BankLinesPage />} />
+          <Route path="/paygw" element={<PAYGWPage />} />
         </Routes>
       </main>
       <footer className="app__footer">

--- a/webapp/src/components/Drawer.tsx
+++ b/webapp/src/components/Drawer.tsx
@@ -1,0 +1,118 @@
+import { ReactNode, useEffect, useId, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import './drawer.css';
+
+type DrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+};
+
+const focusableSelectors =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export default function Drawer({ isOpen, onClose, title, children, footer }: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const previousActiveRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    previousActiveRef.current = document.activeElement as HTMLElement | null;
+
+    const panel = panelRef.current;
+    const focusable = panel
+      ? Array.from(panel.querySelectorAll<HTMLElement>(focusableSelectors)).filter(
+          (element) => !element.hasAttribute('disabled')
+        )
+      : [];
+    const firstFocusable = focusable[0] ?? panel;
+    firstFocusable?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        const panelElement = panelRef.current;
+        if (!panelElement) {
+          return;
+        }
+        const focusableElements = Array.from(
+          panelElement.querySelectorAll<HTMLElement>(focusableSelectors)
+        ).filter((element) => !element.hasAttribute('disabled'));
+
+        if (focusableElements.length === 0) {
+          event.preventDefault();
+          panelElement.focus();
+          return;
+        }
+
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+
+        if (event.shiftKey) {
+          if (active === first || !panelElement.contains(active)) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      previousActiveRef.current?.focus?.();
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="drawer__container" role="presentation">
+      <button
+        type="button"
+        className="drawer__backdrop"
+        aria-label="Close drawer"
+        onClick={onClose}
+      />
+      <aside
+        className="drawer__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        ref={panelRef}
+        tabIndex={-1}
+      >
+        <header className="drawer__header">
+          <h2 id={titleId}>{title}</h2>
+          <button type="button" className="drawer__close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+        <div className="drawer__body">{children}</div>
+        {footer ? <footer className="drawer__footer">{footer}</footer> : null}
+      </aside>
+    </div>,
+    document.body
+  );
+}

--- a/webapp/src/components/drawer.css
+++ b/webapp/src/components/drawer.css
@@ -1,0 +1,83 @@
+.drawer__container {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(12, 18, 33, 0.45);
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.drawer__panel {
+  position: relative;
+  width: min(28rem, 100%);
+  height: 100%;
+  background-color: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-xl) var(--spacing-lg);
+}
+
+.drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.drawer__header h2 {
+  font-size: var(--font-size-lg);
+  letter-spacing: -0.01em;
+}
+
+.drawer__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xl);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.drawer__close:hover {
+  color: var(--color-text);
+}
+
+.drawer__close:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: var(--spacing-xs);
+}
+
+.drawer__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.drawer__panel:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .drawer__panel {
+    width: 100%;
+  }
+}

--- a/webapp/src/pages/PAYGW.css
+++ b/webapp/src/pages/PAYGW.css
@@ -1,0 +1,339 @@
+.paygw-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xl);
+  padding-top: var(--spacing-2xl);
+}
+
+.paygw-header {
+  display: grid;
+  gap: var(--spacing-xs);
+  max-width: 44rem;
+}
+
+.paygw-header h1 {
+  font-size: var(--font-size-2xl);
+  letter-spacing: -0.03em;
+}
+
+.paygw-header p {
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
+}
+
+.paygw-alert {
+  position: relative;
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  padding: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-sm);
+  box-shadow: var(--shadow-sm);
+}
+
+.paygw-alert__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+}
+
+.paygw-alert__title {
+  font-size: var(--font-size-lg);
+  display: flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+}
+
+.paygw-alert__actions {
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.paygw-alert__actions button {
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-pill);
+  padding: var(--spacing-2xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+.paygw-alert__actions button:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.paygw-alert--warning {
+  border-color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 16%, transparent);
+}
+
+.paygw-alert--danger {
+  border-color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 16%, transparent);
+}
+
+[data-theme='dark'] .paygw-alert--warning {
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
+}
+
+[data-theme='dark'] .paygw-alert--danger {
+  background: color-mix(in srgb, var(--color-danger) 22%, transparent);
+}
+
+.paygw-table-container {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.paygw-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 48rem;
+}
+
+.paygw-table thead {
+  background-color: var(--color-surface-muted);
+}
+
+.paygw-table th,
+.paygw-table td {
+  padding: var(--spacing-md) var(--spacing-lg);
+  text-align: left;
+  font-size: var(--font-size-sm);
+}
+
+.paygw-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.paygw-table tbody tr + tr {
+  border-top: 1px solid var(--color-border);
+}
+
+.paygw-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3xs);
+  border-radius: var(--radius-pill);
+  padding: var(--spacing-3xs) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+}
+
+.paygw-status--pending {
+  color: var(--status-pending-fg);
+  background-color: var(--status-pending-bg);
+}
+
+.paygw-status--monitor {
+  color: var(--status-monitor-fg);
+  background-color: var(--status-monitor-bg);
+}
+
+.paygw-status--active {
+  color: var(--status-active-fg);
+  background-color: var(--status-active-bg);
+}
+
+.paygw-remediate {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: var(--spacing-2xs) var(--spacing-sm);
+  background-color: var(--color-surface);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.paygw-remediate:hover {
+  border-color: var(--color-border-strong);
+}
+
+.paygw-remediate:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.paygw-checklist {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-md);
+  max-width: 32rem;
+}
+
+.paygw-checklist h2 {
+  font-size: var(--font-size-lg);
+}
+
+.paygw-checklist ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.paygw-checklist li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+}
+
+.paygw-checklist input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+}
+
+.paygw-steps {
+  display: grid;
+  gap: var(--spacing-sm);
+  margin: 0 0 var(--spacing-lg) 0;
+  padding: 0;
+  list-style: none;
+}
+
+.paygw-step {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.paygw-step--active {
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
+.paygw-step__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--radius-pill);
+  background-color: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.paygw-step--active .paygw-step__index {
+  background-color: var(--color-primary);
+  color: var(--color-primary-contrast);
+}
+
+.paygw-form-group {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.paygw-variance-summary {
+  margin-bottom: var(--spacing-lg);
+}
+
+.paygw-variance-summary__label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+}
+
+.paygw-variance-summary__value {
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+
+.paygw-form-group label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.paygw-select,
+.paygw-textarea,
+.paygw-file {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  background-color: var(--color-surface);
+}
+
+.paygw-radio-group {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.paygw-radio-option {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.paygw-notes-upload {
+  gap: var(--spacing-lg);
+}
+
+.paygw-drawer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  width: 100%;
+}
+
+.paygw-secondary-button,
+.paygw-primary-button {
+  border-radius: var(--radius-pill);
+  padding: var(--spacing-2xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+
+.paygw-secondary-button {
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+}
+
+.paygw-primary-button {
+  border: none;
+  background-color: var(--color-primary);
+  color: var(--color-primary-contrast);
+  box-shadow: var(--shadow-sm);
+}
+
+.paygw-secondary-button:focus-visible,
+.paygw-primary-button:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.paygw-empty-state {
+  padding: var(--spacing-lg);
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 900px) {
+  .paygw-table {
+    min-width: unset;
+  }
+
+  .paygw-table-container {
+    overflow-x: auto;
+  }
+}

--- a/webapp/src/pages/PAYGW.tsx
+++ b/webapp/src/pages/PAYGW.tsx
@@ -1,0 +1,382 @@
+import { FormEvent, useId, useMemo, useState } from 'react';
+import Drawer from '../components/Drawer';
+import './PAYGW.css';
+
+type Variance = {
+  id: string;
+  date: string;
+  payee: string;
+  description: string;
+  amount: string;
+  status: string;
+  statusVariant: 'pending' | 'monitor' | 'active';
+};
+
+const variances: Variance[] = [
+  {
+    id: '1',
+    date: '2024-04-12',
+    payee: 'SummitWorks Staffing',
+    description: 'Labour hire variance following shift premiums',
+    amount: '$42,180.00',
+    status: 'Pending review',
+    statusVariant: 'pending'
+  },
+  {
+    id: '2',
+    date: '2024-04-10',
+    payee: 'Metro Industrial Cleaning',
+    description: 'Service invoice mismatch (partial delivery)',
+    amount: '$18,640.00',
+    status: 'Under monitoring',
+    statusVariant: 'monitor'
+  },
+  {
+    id: '3',
+    date: '2024-04-08',
+    payee: 'Northern Equipment Finance',
+    description: 'Deferred lease payment variance (30 days)',
+    amount: '$76,210.00',
+    status: 'Resolution pending',
+    statusVariant: 'pending'
+  },
+  {
+    id: '4',
+    date: '2024-04-02',
+    payee: 'Brightline Logistics',
+    description: 'Carrier rate update applied retroactively',
+    amount: '$9,420.00',
+    status: 'Closed - adjustments posted',
+    statusVariant: 'active'
+  }
+];
+
+const statusClassMap: Record<Variance['statusVariant'], string> = {
+  pending: 'paygw-status paygw-status--pending',
+  monitor: 'paygw-status paygw-status--monitor',
+  active: 'paygw-status paygw-status--active'
+};
+
+const wizardSteps = ['Classify issue', 'Choose action', 'Add notes & upload evidence'];
+
+type ChecklistItem = {
+  id: string;
+  label: string;
+  complete: boolean;
+};
+
+export default function PAYGWPage() {
+  const [alertVisible, setAlertVisible] = useState(true);
+  const [alertEscalated, setAlertEscalated] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activeVariance, setActiveVariance] = useState<Variance | null>(null);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [classification, setClassification] = useState('');
+  const [action, setAction] = useState('');
+  const [notes, setNotes] = useState('');
+  const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
+
+  const formId = useId();
+  const classificationId = useId();
+  const actionAdjustId = useId();
+  const actionRescheduleId = useId();
+  const actionPlanId = useId();
+  const notesId = useId();
+  const fileId = useId();
+
+  const checklist: ChecklistItem[] = useMemo(
+    () => [
+      {
+        id: 'alert',
+        label: 'Alert acknowledged',
+        complete: !alertVisible
+      },
+      {
+        id: 'investigation',
+        label: 'Investigation classified',
+        complete: classification !== ''
+      },
+      {
+        id: 'resolution',
+        label: 'Resolution path selected',
+        complete: action !== ''
+      },
+      {
+        id: 'docs',
+        label: 'Documentation captured',
+        complete: notes.trim().length > 0 || Boolean(evidenceFile)
+      }
+    ],
+    [action, alertVisible, classification, evidenceFile, notes]
+  );
+
+  const handleOpenDrawer = (variance: Variance) => {
+    setActiveVariance(variance);
+    setDrawerOpen(true);
+    setCurrentStep(0);
+    setClassification('');
+    setAction('');
+    setNotes('');
+    setEvidenceFile(null);
+  };
+
+  const handleCloseDrawer = () => {
+    setDrawerOpen(false);
+  };
+
+  const handleNextStep = () => {
+    setCurrentStep((previous) => Math.min(previous + 1, wizardSteps.length - 1));
+  };
+
+  const handlePreviousStep = () => {
+    setCurrentStep((previous) => Math.max(previous - 1, 0));
+  };
+
+  const handleWizardSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // Stub persistence hook for future API integration.
+    console.info('Variance remediation submitted', {
+      varianceId: activeVariance?.id,
+      classification,
+      action,
+      notesLength: notes.trim().length,
+      evidence: evidenceFile?.name ?? 'none'
+    });
+    setDrawerOpen(false);
+  };
+
+  const isLastStep = currentStep === wizardSteps.length - 1;
+
+  return (
+    <div className="paygw-page">
+      <header className="paygw-header">
+        <h1>PAYGW variance flow</h1>
+        <p>
+          Investigate and remediate withholding discrepancies with a guided workflow that
+          captures classification, corrective actions, and supporting evidence.
+        </p>
+      </header>
+
+      {alertVisible ? (
+        <section
+          className={`paygw-alert ${alertEscalated ? 'paygw-alert--danger' : 'paygw-alert--warning'}`}
+          role="alert"
+          aria-live="polite"
+        >
+          <div className="paygw-alert__header">
+            <div>
+              <p className="paygw-alert__title">
+                {alertEscalated ? 'Escalated variance requiring action' : 'Variance detected in PAYGW flow'}
+              </p>
+              <p>
+                Quarterly lodgement shows a variance that exceeds the automated tolerance threshold.
+                Launch an investigation or escalate for immediate attention.
+              </p>
+            </div>
+            <div className="paygw-alert__actions">
+              <button type="button" onClick={() => setAlertEscalated((value) => !value)}>
+                {alertEscalated ? 'Mark as contained' : 'Escalate'}
+              </button>
+              <button type="button" onClick={() => setAlertVisible(false)}>
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="paygw-table-container" aria-label="Variance queue">
+        <table className="paygw-table">
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Payee</th>
+              <th scope="col">Description</th>
+              <th scope="col">Amount</th>
+              <th scope="col">Status</th>
+              <th scope="col">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {variances.length === 0 ? (
+              <tr>
+                <td colSpan={6}>
+                  <div className="paygw-empty-state">No variances to display.</div>
+                </td>
+              </tr>
+            ) : (
+              variances.map((variance) => (
+                <tr key={variance.id}>
+                  <td>{variance.date}</td>
+                  <td>{variance.payee}</td>
+                  <td>{variance.description}</td>
+                  <td>{variance.amount}</td>
+                  <td>
+                    <span className={statusClassMap[variance.statusVariant]}>{variance.status}</span>
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      className="paygw-remediate"
+                      onClick={() => handleOpenDrawer(variance)}
+                    >
+                      Remediate
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="paygw-checklist" aria-label="Variance remediation checklist">
+        <h2>Alert → investigation → resolution → docs</h2>
+        <ul>
+          {checklist.map((item) => (
+            <li key={item.id}>
+              <input type="checkbox" checked={item.complete} readOnly aria-describedby={`${item.id}-label`} />
+              <span id={`${item.id}-label`}>{item.label}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <Drawer
+        isOpen={drawerOpen}
+        onClose={handleCloseDrawer}
+        title={activeVariance ? `Remediate ${activeVariance.payee}` : 'Variance remediation'}
+        footer={
+          <div className="paygw-drawer-footer">
+            {currentStep > 0 ? (
+              <button type="button" className="paygw-secondary-button" onClick={handlePreviousStep}>
+                Back
+              </button>
+            ) : null}
+            {!isLastStep ? (
+              <button type="button" className="paygw-primary-button" onClick={handleNextStep}>
+                Continue
+              </button>
+            ) : (
+              <button type="submit" form={formId} className="paygw-primary-button">
+                Complete remediation
+              </button>
+            )}
+          </div>
+        }
+      >
+        <form id={formId} onSubmit={handleWizardSubmit}>
+          {activeVariance ? (
+            <div className="paygw-form-group paygw-variance-summary">
+              <p className="paygw-variance-summary__label">Variance summary</p>
+              <p className="paygw-variance-summary__value">
+                {activeVariance.description} — {activeVariance.amount} ({activeVariance.date})
+              </p>
+            </div>
+          ) : null}
+
+          <ol className="paygw-steps">
+            {wizardSteps.map((step, index) => (
+              <li
+                key={step}
+                className={`paygw-step ${index === currentStep ? 'paygw-step--active' : ''}`}
+              >
+                <span className="paygw-step__index">{index + 1}</span>
+                {step}
+              </li>
+            ))}
+          </ol>
+
+          {currentStep === 0 ? (
+            <div className="paygw-form-group">
+              <label htmlFor={classificationId}>Issue classification</label>
+              <select
+                id={classificationId}
+                className="paygw-select"
+                value={classification}
+                onChange={(event) => setClassification(event.target.value)}
+                required
+              >
+                <option value="" disabled>
+                  Select classification
+                </option>
+                <option value="processing-error">Processing error</option>
+                <option value="timing-variance">Timing variance</option>
+                <option value="supplier-misreport">Supplier misreport</option>
+                <option value="potential-fraud">Potential fraud</option>
+              </select>
+            </div>
+          ) : null}
+
+          {currentStep === 1 ? (
+            <fieldset className="paygw-form-group">
+              <legend>Choose corrective action</legend>
+              <div className="paygw-radio-group">
+                <label className="paygw-radio-option" htmlFor={actionAdjustId}>
+                  <input
+                    type="radio"
+                    id={actionAdjustId}
+                    name="action"
+                    value="adjust-funds"
+                    checked={action === 'adjust-funds'}
+                    onChange={(event) => setAction(event.target.value)}
+                    required
+                  />
+                  Adjust funds
+                </label>
+                <label className="paygw-radio-option" htmlFor={actionRescheduleId}>
+                  <input
+                    type="radio"
+                    id={actionRescheduleId}
+                    name="action"
+                    value="reschedule"
+                    checked={action === 'reschedule'}
+                    onChange={(event) => setAction(event.target.value)}
+                  />
+                  Reschedule remittance
+                </label>
+                <label className="paygw-radio-option" htmlFor={actionPlanId}>
+                  <input
+                    type="radio"
+                    id={actionPlanId}
+                    name="action"
+                    value="payment-plan"
+                    checked={action === 'payment-plan'}
+                    onChange={(event) => setAction(event.target.value)}
+                  />
+                  Establish payment plan
+                </label>
+              </div>
+            </fieldset>
+          ) : null}
+
+          {currentStep === 2 ? (
+            <div className="paygw-form-group paygw-notes-upload">
+              <div className="paygw-form-group">
+                <label htmlFor={notesId}>Investigation notes</label>
+                <textarea
+                  id={notesId}
+                  className="paygw-textarea"
+                  rows={4}
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  placeholder="Summarise findings, stakeholder outreach, and pending decisions"
+                />
+              </div>
+              <div className="paygw-form-group">
+                <label htmlFor={fileId}>Upload evidence</label>
+                <input
+                  id={fileId}
+                  className="paygw-file"
+                  type="file"
+                  onChange={(event) => setEvidenceFile(event.target.files?.[0] ?? null)}
+                />
+                {evidenceFile ? <span>Attached: {evidenceFile.name}</span> : null}
+              </div>
+            </div>
+          ) : null}
+        </form>
+      </Drawer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a PAYGW variance workflow page with alert messaging, remediation table, and investigation checklist
- implement an accessible right-side drawer wizard for remediation actions
- register the PAYGW flow in the main navigation

## Testing
- pnpm --filter webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f768c5371483279833b206e3830c84