### PR TITLE
Add obligations control room dashboard

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import HomePage from './pages/Home';
 import BankLinesPage from './pages/BankLines';
+import ObligationsPage from './pages/Obligations';
 import './App.css';
 
 type Theme = 'light' | 'dark';
@@ -44,6 +45,9 @@ export default function App() {
           <NavLink className="app__nav-link" to="/" end>
             Overview
           </NavLink>
+          <NavLink className="app__nav-link" to="/obligations">
+            Obligations
+          </NavLink>
           <NavLink className="app__nav-link" to="/bank-lines">
             Bank lines
           </NavLink>
@@ -60,6 +64,7 @@ export default function App() {
       <main className="app__content">
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/obligations" element={<ObligationsPage />} />
           <Route path="/bank-lines" element={<BankLinesPage />} />
         </Routes>
       </main>

--- a/webapp/src/pages/Obligations.css
+++ b/webapp/src/pages/Obligations.css
@@ -1,0 +1,165 @@
+.obligations {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2xl);
+  padding-top: var(--spacing-2xl);
+}
+
+.obligations__header {
+  display: grid;
+  gap: var(--spacing-xl);
+  align-items: start;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.obligations__summary {
+  display: grid;
+  gap: var(--spacing-sm);
+  max-width: 46rem;
+}
+
+.obligations__summary h1 {
+  font-size: var(--font-size-2xl);
+  letter-spacing: -0.03em;
+}
+
+.obligations__summary p {
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
+  line-height: var(--font-lineheight-relaxed);
+}
+
+.obligations__posture {
+  display: grid;
+  gap: var(--spacing-sm);
+  justify-items: start;
+}
+
+.obligations__posture-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-badge {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--spacing-3xs);
+  padding: var(--spacing-2xs) var(--spacing-sm);
+  border-radius: var(--radius-md);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--shadow-sm);
+  min-width: 12rem;
+}
+
+.status-badge__label {
+  font-size: var(--font-size-sm);
+  line-height: var(--font-lineheight-tight);
+}
+
+.status-badge__description {
+  font-size: var(--font-size-xs);
+  line-height: var(--font-lineheight-cozy);
+}
+
+.status-badge--active {
+  background-color: var(--status-active-bg);
+  color: var(--status-active-fg);
+}
+
+.status-badge--active .status-badge__description {
+  color: var(--status-active-hint-fg);
+}
+
+.status-badge--monitoring {
+  background-color: var(--status-monitor-bg);
+  color: var(--status-monitor-fg);
+}
+
+.status-badge--monitoring .status-badge__description {
+  color: var(--status-monitor-hint-fg);
+}
+
+.status-badge--pending {
+  background-color: var(--status-pending-bg);
+  color: var(--status-pending-fg);
+}
+
+.status-badge--pending .status-badge__description {
+  color: var(--status-pending-hint-fg);
+}
+
+.obligations__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: var(--spacing-xl);
+}
+
+.obligations-metric-card {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.obligations-metric-card__header h2 {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.obligations-metric-card__value {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-lineheight-tight);
+}
+
+.obligations-metric-card__sublabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--font-lineheight-relaxed);
+}
+
+.obligations-metric-card__sparkline {
+  width: 100%;
+  height: 2.5rem;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, rgba(86, 96, 121, 0.16) 0%, rgba(86, 96, 121, 0.35) 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.obligations-metric-card__sparkline::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 80%, rgba(255, 255, 255, 0.7) 0%, transparent 55%),
+    radial-gradient(circle at 60% 30%, rgba(255, 255, 255, 0.35) 0%, transparent 60%);
+  mix-blend-mode: screen;
+}
+
+.obligations-metric-card__sparkline--positive {
+  background: linear-gradient(90deg, rgba(10, 125, 87, 0.15) 0%, rgba(10, 125, 87, 0.55) 100%);
+}
+
+.obligations-metric-card__sparkline--negative {
+  background: linear-gradient(90deg, rgba(196, 71, 71, 0.18) 0%, rgba(196, 71, 71, 0.6) 100%);
+}
+
+.obligations-metric-card__sparkline--neutral {
+  background: linear-gradient(90deg, rgba(0, 90, 214, 0.16) 0%, rgba(0, 90, 214, 0.42) 100%);
+}
+
+@media (max-width: 720px) {
+  .status-badge {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/webapp/src/pages/Obligations.tsx
+++ b/webapp/src/pages/Obligations.tsx
@@ -1,0 +1,101 @@
+import './Obligations.css';
+
+import type { ReactNode } from 'react';
+
+type StatusBadgeVariant = 'active' | 'monitoring' | 'pending';
+
+type StatusBadgeProps = {
+  variant: StatusBadgeVariant;
+  label: string;
+  description: string;
+};
+
+function StatusBadge({ variant, label, description }: StatusBadgeProps) {
+  return (
+    <span className={`status-badge status-badge--${variant}`}>
+      <span className="status-badge__label">{label}</span>
+      <span className="status-badge__description">{description}</span>
+    </span>
+  );
+}
+
+type MetricTrend = 'positive' | 'negative' | 'neutral';
+
+type MetricCard = {
+  id: string;
+  title: string;
+  value: string;
+  sublabel: ReactNode;
+  trend: MetricTrend;
+};
+
+const metrics: MetricCard[] = [
+  {
+    id: 'paygw',
+    title: 'PAYGW secured vs liability',
+    value: '$245k',
+    sublabel: '92% of the $266k obligation secured across trust accounts',
+    trend: 'positive'
+  },
+  {
+    id: 'gst',
+    title: 'GST secured vs liability',
+    value: '$198k',
+    sublabel: '86% of the $231k remittance covered by reserve',
+    trend: 'positive'
+  },
+  {
+    id: 'variance',
+    title: 'Variance',
+    value: '-$18.5k',
+    sublabel: 'Movement since the prior BAS lodgement window',
+    trend: 'negative'
+  },
+  {
+    id: 'next-bas',
+    title: 'Next BAS due',
+    value: '30 Oct 2024',
+    sublabel: 'Preparation window open • CFO sign-off scheduled in 14 days',
+    trend: 'neutral'
+  }
+];
+
+export default function ObligationsPage() {
+  return (
+    <div className="obligations">
+      <header className="obligations__header">
+        <div className="obligations__summary">
+          <h1>Obligation control room</h1>
+          <p>
+            Monitor statutory lodgements, withheld tax positions, and trust account coverage to
+            keep compliance teams aligned on upcoming remittances.
+          </p>
+        </div>
+        <div className="obligations__posture" aria-label="Overall compliance posture">
+          <span className="obligations__posture-label">Compliance posture</span>
+          <StatusBadge
+            variant="active"
+            label="On track"
+            description="All lodgements secured and reconciled"
+          />
+        </div>
+      </header>
+
+      <section className="obligations__metrics" aria-label="Obligation metrics">
+        {metrics.map((metric) => (
+          <article className="obligations-metric-card" key={metric.id}>
+            <header className="obligations-metric-card__header">
+              <h2>{metric.title}</h2>
+            </header>
+            <p className="obligations-metric-card__value">{metric.value}</p>
+            <p className="obligations-metric-card__sublabel">{metric.sublabel}</p>
+            <div
+              className={`obligations-metric-card__sparkline obligations-metric-card__sparkline--${metric.trend}`}
+              aria-hidden="true"
+            />
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an obligations control room page with metric cards and compliance badge
- wire the new page into the app shell navigation

## Testing
- `pnpm --filter webapp build`


------
https://chatgpt.com/codex/tasks/task_e_68f768b676c883278f9cfcf32f3a8e75