### PR TITLE
Add reusable status badge component

### DIFF
--- a/webapp/src/components/ui/StatusBadge.tsx
+++ b/webapp/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,33 @@
+export type StatusBadgeVariant = 'active' | 'monitoring' | 'pending';
+
+export const statusBadgeClasses = {
+  root: 'status-badge',
+  label: 'status-badge__label',
+  hint: 'status-badge__hint',
+  variants: {
+    active: 'status-badge--active',
+    monitoring: 'status-badge--monitoring',
+    pending: 'status-badge--pending'
+  } satisfies Record<StatusBadgeVariant, string>
+};
+
+export type StatusBadgeProps = {
+  variant: StatusBadgeVariant;
+  label: string;
+  hint?: string;
+  ariaLabel?: string;
+};
+
+export function StatusBadge({ variant, label, hint, ariaLabel }: StatusBadgeProps) {
+  return (
+    <span
+      className={`${statusBadgeClasses.root} ${statusBadgeClasses.variants[variant]}`}
+      aria-label={ariaLabel}
+    >
+      <span className={statusBadgeClasses.label}>{label}</span>
+      {hint ? <span className={statusBadgeClasses.hint}>{hint}</span> : null}
+    </span>
+  );
+}
+
+export default StatusBadge;

--- a/webapp/src/pages/BankLines.tsx
+++ b/webapp/src/pages/BankLines.tsx
@@ -1,4 +1,5 @@
-﻿import './BankLines.css';
+import './BankLines.css';
+import StatusBadge from '../components/ui/StatusBadge';
 
 type LineStatus = 'Active' | 'Pending' | 'Monitoring';
 
@@ -90,10 +91,11 @@ export default function BankLinesPage() {
                   </div>
                 </td>
                 <td>
-                  <span className={`status-badge status-badge--${line.status.toLowerCase()}`}>
-                    <span className="status-badge__label">{line.status}</span>
-                    <span className="status-badge__hint">{statusLabels[line.status]}</span>
-                  </span>
+                  <StatusBadge
+                    variant={line.status.toLowerCase() as 'active' | 'monitoring' | 'pending'}
+                    label={line.status}
+                    hint={statusLabels[line.status]}
+                  />
                 </td>
                 <td>{line.updated}</td>
                 <td>{line.notes}</td>


### PR DESCRIPTION
## Summary
- add a reusable `StatusBadge` component that exposes the existing badge class names
- switch the Bank Lines page to render the new component instead of duplicating markup

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f768a5f18483278faebd9d7f44467b