### PR TITLE
feat(webapp): add card and table UI primitives

### DIFF
--- a/webapp/src/components/ui/Card.tsx
+++ b/webapp/src/components/ui/Card.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+import './card.css';
+
+type CardProps = {
+  /**
+   * Optional title rendered in the card header. Strings are wrapped in an h3 for semantics,
+   * while custom nodes are rendered as-is.
+   */
+  title?: ReactNode;
+  /**
+   * Optional content rendered inside the card footer.
+   */
+  footer?: ReactNode;
+  /**
+   * Main content of the card, rendered within the body section.
+   */
+  children: ReactNode;
+  /**
+   * Additional className applied to the card container.
+   */
+  className?: string;
+};
+
+export default function Card({ title, footer, children, className }: CardProps) {
+  const hasHeader = title !== undefined && title !== null;
+  const hasFooter = footer !== undefined && footer !== null;
+  const classes = ['card', className].filter(Boolean).join(' ');
+
+  return (
+    <section className={classes}>
+      {hasHeader ? (
+        <header className="card__header">
+          {typeof title === 'string' ? <h3 className="card__title">{title}</h3> : title}
+        </header>
+      ) : null}
+      <div className="card__body">{children}</div>
+      {hasFooter ? <footer className="card__footer">{footer}</footer> : null}
+    </section>
+  );
+}

--- a/webapp/src/components/ui/Table.tsx
+++ b/webapp/src/components/ui/Table.tsx
@@ -1,0 +1,52 @@
+import type {
+  HTMLAttributes,
+  TableHTMLAttributes,
+  ThHTMLAttributes,
+  TdHTMLAttributes,
+} from 'react';
+import './table.css';
+
+type TableProps = TableHTMLAttributes<HTMLTableElement> & {
+  /** Enables sticky table header styling when true. */
+  stickyHeader?: boolean;
+};
+
+type TSectionProps<T> = HTMLAttributes<T> & { className?: string };
+
+type TableHeaderCellProps = ThHTMLAttributes<HTMLTableCellElement> & { className?: string };
+type TableDataCellProps = TdHTMLAttributes<HTMLTableCellElement> & { className?: string };
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export function Table({ className, stickyHeader = false, children, ...rest }: TableProps) {
+  const wrapperClass = cx('table__wrapper', stickyHeader && 'table__wrapper--sticky');
+  const tableClass = cx('table', className, stickyHeader && 'table--sticky');
+
+  return (
+    <div className={wrapperClass}>
+      <table className={tableClass} {...rest}>
+        {children}
+      </table>
+    </div>
+  );
+}
+
+export function THead({ className, ...rest }: TSectionProps<HTMLTableSectionElement>) {
+  return <thead className={cx('table__head', className)} {...rest} />;
+}
+
+export function TBody({ className, ...rest }: TSectionProps<HTMLTableSectionElement>) {
+  return <tbody className={cx('table__body', className)} {...rest} />;
+}
+
+export function Th({ className, ...rest }: TableHeaderCellProps) {
+  return <th className={cx('table__cell', 'table__cell--head', className)} {...rest} />;
+}
+
+export function Td({ className, ...rest }: TableDataCellProps) {
+  return <td className={cx('table__cell', className)} {...rest} />;
+}
+
+export default Table;

--- a/webapp/src/components/ui/card.css
+++ b/webapp/src/components/ui/card.css
@@ -1,0 +1,92 @@
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.card__header,
+.card__footer {
+  padding: var(--spacing-lg);
+  background: var(--color-surface);
+}
+
+.card__header {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--font-lineheight-cozy);
+  color: var(--color-text);
+}
+
+.card__body {
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  color: var(--color-text);
+}
+
+.card__footer {
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2xs);
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--font-lineheight-cozy);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--color-focus);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-primary-contrast);
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-primary) 90%, black 10%);
+  border-color: color-mix(in srgb, var(--color-primary) 85%, black 15%);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-primary);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
+}

--- a/webapp/src/components/ui/table.css
+++ b/webapp/src/components/ui/table.css
@@ -1,0 +1,77 @@
+.table__wrapper {
+  width: 100%;
+  overflow-x: auto;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.table__wrapper--sticky {
+  max-height: 28rem;
+  overflow-y: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 100%;
+  color: var(--color-text);
+}
+
+.table__head th,
+.table__body td {
+  padding: var(--spacing-sm) var(--spacing-lg);
+}
+
+.table__head {
+  position: relative;
+  background: var(--color-surface-muted);
+}
+
+.table__cell {
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  font-size: var(--font-size-sm);
+  line-height: var(--font-lineheight-cozy);
+}
+
+.table__cell--head {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  text-transform: none;
+  background: var(--color-surface-muted);
+  position: relative;
+  z-index: 1;
+}
+
+.table__wrapper--sticky .table--sticky thead th {
+  position: sticky;
+  top: 0;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.04);
+}
+
+.table__body tr:last-of-type .table__cell {
+  border-bottom: none;
+}
+
+.table__body tr:hover .table__cell {
+  background: var(--color-primary-soft);
+}
+
+.table__body tr:nth-child(even) .table__cell {
+  background: color-mix(in srgb, var(--color-surface) 92%, var(--color-surface-muted) 8%);
+}
+
+.table__body tr:nth-child(even):hover .table__cell {
+  background: var(--color-primary-soft);
+}
+
+.table__cell:first-of-type {
+  border-left: none;
+}
+
+.table__cell:last-of-type {
+  border-right: none;
+}


### PR DESCRIPTION
## Summary
- add a reusable card component with optional header/footer sections and shared button styles
- add a table utility with sticky header support and hover interactions

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f76891534c8327a9ec123058804c9c