### PR TITLE
Align primary nav with compliance playbook

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -26,24 +26,34 @@
 
 .app__nav {
   display: flex;
-  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
   align-items: center;
 }
 
 .app__nav-link {
   position: relative;
-  padding: var(--spacing-xs) var(--spacing-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 var(--spacing-md);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
   text-decoration: none;
   border-radius: var(--radius-pill);
-  transition: color 180ms ease, background-color 180ms ease;
+  transition: color 180ms ease, background-color 180ms ease, box-shadow 180ms ease;
 }
 
-.app__nav-link[aria-current='page'] {
-  color: var(--color-primary-contrast);
-  background-color: var(--color-primary);
+.app__nav-link:hover {
+  background-color: var(--color-surface-muted);
+  color: var(--color-text);
+}
+
+.app__nav a.active {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
   box-shadow: var(--shadow-sm);
 }
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,10 +1,17 @@
-﻿import { NavLink, Route, Routes } from 'react-router-dom';
-import { useEffect, useMemo, useState } from 'react';
+import { NavLink, Route, Routes } from 'react-router-dom';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import HomePage from './pages/Home';
 import BankLinesPage from './pages/BankLines';
 import './App.css';
 
 type Theme = 'light' | 'dark';
+
+type NavItem = {
+  path: string;
+  label: string;
+  element: ReactNode;
+  end?: boolean;
+};
 
 const themeOrder: Theme[] = ['light', 'dark'];
 
@@ -21,6 +28,87 @@ function getInitialTheme(): Theme {
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   return prefersDark ? 'dark' : 'light';
 }
+
+function PlaceholderPage({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="page">
+      <header className="page__header">
+        <h1>{title}</h1>
+        <p>{description}</p>
+      </header>
+      <section aria-label={`${title} insights`}>
+        <p>
+          Detailed playbooks for this area are being compiled. Review outstanding tasks, risk
+          indicators, and policy updates with your operations team to stay compliant.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+const navItems: NavItem[] = [
+  {
+    path: '/',
+    label: 'Overview',
+    element: <HomePage />,
+    end: true
+  },
+  {
+    path: '/bank-lines',
+    label: 'Bank lines',
+    element: <BankLinesPage />
+  },
+  {
+    path: '/obligations',
+    label: 'Obligations',
+    element: (
+      <PlaceholderPage
+        title="Obligations dashboard"
+        description="Track covenant timelines, repayment schedules, and sign-off workflows across mandates."
+      />
+    )
+  },
+  {
+    path: '/paygw',
+    label: 'PAYGW',
+    element: (
+      <PlaceholderPage
+        title="PAYGW compliance"
+        description="Monitor payroll withholding submissions, variance alerts, and follow-up actions with the finance pod."
+      />
+    )
+  },
+  {
+    path: '/gst',
+    label: 'GST',
+    element: (
+      <PlaceholderPage
+        title="GST lodgements"
+        description="Consolidate statement reviews, reconcile adjustments, and coordinate filings for cross-border portfolios."
+      />
+    )
+  },
+  {
+    path: '/compliance',
+    label: 'Compliance',
+    element: (
+      <PlaceholderPage
+        title="Compliance operations"
+        description="Align regulatory attestations, policy renewals, and audit responses with risk stakeholders."
+      />
+    )
+  },
+  {
+    path: '/security',
+    label: 'Security',
+    element: (
+      <PlaceholderPage
+        title="Security oversight"
+        description="Review incident queues, access provisioning, and resiliency readiness across your capital markets stack."
+      />
+    )
+  }
+];
 
 export default function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
@@ -41,12 +129,16 @@ export default function App() {
       <header className="app__header">
         <div className="app__brand">APGMS Pro+</div>
         <nav className="app__nav" aria-label="Primary">
-          <NavLink className="app__nav-link" to="/" end>
-            Overview
-          </NavLink>
-          <NavLink className="app__nav-link" to="/bank-lines">
-            Bank lines
-          </NavLink>
+          {navItems.map(({ path, label, end }) => (
+            <NavLink
+              key={path}
+              to={path}
+              end={end}
+              className={({ isActive }) => `app__nav-link${isActive ? ' active' : ''}`}
+            >
+              {label}
+            </NavLink>
+          ))}
         </nav>
         <button
           type="button"
@@ -54,13 +146,14 @@ export default function App() {
           onClick={() => setTheme(nextTheme)}
           aria-label={`Switch to ${nextTheme} theme`}
         >
-          {theme === 'light' ? 'ðŸŒž' : 'ðŸŒ™'}
+          {theme === 'light' ? '🌞' : '🌙'}
         </button>
       </header>
       <main className="app__content">
         <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/bank-lines" element={<BankLinesPage />} />
+          {navItems.map(({ path, element }) => (
+            <Route key={path} path={path} element={element} />
+          ))}
         </Routes>
       </main>
       <footer className="app__footer">


### PR DESCRIPTION
## Summary
- expand the primary navigation to cover Obligations, PAYGW, GST, Compliance, and Security with placeholder content
- centralize nav definitions so active routes add the expected active class styling
- restyle navigation links to meet the playbook hover/active colors and minimum target size

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f7688208508327a960594a7a9ac64a