### PR TITLE
feat(webapp): introduce app shell layout and placeholder routes

### DIFF
--- a/webapp/src/components/layout/AppShell.tsx
+++ b/webapp/src/components/layout/AppShell.tsx
@@ -1,0 +1,75 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import './appshell.css';
+
+export type Theme = 'light' | 'dark';
+
+export function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem('apgms-theme');
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'dark' : 'light';
+}
+
+const navLinks = [
+  { to: '/', label: 'Obligations', end: true },
+  { to: '/paygw', label: 'PAYGW' },
+  { to: '/gst', label: 'GST' },
+  { to: '/compliance', label: 'Compliance' },
+  { to: '/security', label: 'Security' },
+];
+
+export default function AppShell() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    window.localStorage.setItem('apgms-theme', theme);
+  }, [theme]);
+
+  const nextTheme = useMemo<Theme>(() => (theme === 'light' ? 'dark' : 'light'), [theme]);
+
+  return (
+    <div className="app-shell">
+      <header className="app-shell__topbar">
+        <div className="app-shell__brand">APGMS Pro+</div>
+        <button
+          type="button"
+          className="app-shell__theme-toggle"
+          onClick={() => setTheme(nextTheme)}
+          aria-label={`Switch to ${nextTheme} theme`}
+        >
+          {theme === 'light' ? '🌞' : '🌜'}
+        </button>
+      </header>
+      <div className="app-shell__layout">
+        <nav className="app-shell__nav" aria-label="Primary">
+          {navLinks.map(({ to, label, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                isActive
+                  ? 'app-shell__nav-link app-shell__nav-link--active'
+                  : 'app-shell__nav-link'
+              }
+            >
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+        <main className="app-shell__main">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/layout/appshell.css
+++ b/webapp/src/components/layout/appshell.css
@@ -1,0 +1,122 @@
+.app-shell {
+  min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-sans);
+}
+
+.app-shell__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-xl);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-shell__brand {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.app-shell__theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.app-shell__theme-toggle:hover {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.app-shell__layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-lg) var(--spacing-lg) var(--spacing-2xl);
+}
+
+.app-shell__nav {
+  display: flex;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow-x: auto;
+}
+
+.app-shell__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-pill);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: var(--font-weight-medium);
+  transition: color 0.2s ease, background 0.2s ease;
+  white-space: nowrap;
+}
+
+.app-shell__nav-link:hover {
+  color: var(--color-primary);
+}
+
+.app-shell__nav-link--active {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.app-shell__main {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--spacing-xl);
+}
+
+.app-shell__main > * + * {
+  margin-top: var(--spacing-lg);
+}
+
+.app-shell__theme-toggle:focus-visible,
+.app-shell__nav-link:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+@media (min-width: 900px) {
+  .app-shell__layout {
+    display: grid;
+    grid-template-columns: 16rem 1fr;
+    gap: var(--spacing-xl);
+    padding: var(--spacing-xl) var(--spacing-2xl);
+  }
+
+  .app-shell__nav {
+    flex-direction: column;
+    min-height: calc(100vh - 6rem);
+    padding: var(--spacing-lg) var(--spacing-md);
+    position: sticky;
+    top: calc(var(--spacing-xl) + 3rem);
+  }
+
+  .app-shell__nav-link {
+    width: 100%;
+  }
+}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,9 +1,20 @@
-﻿import React from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import App from './App';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import AppShell, { getInitialTheme } from './components/layout/AppShell';
+import Obligations from './pages/Obligations';
+import PAYGW from './pages/PAYGW';
+import GST from './pages/GST';
+import Compliance from './pages/Compliance';
+import Security from './pages/Security';
 import './styles/tokens.css';
 import './styles/global.css';
+
+if (typeof window !== 'undefined') {
+  const initialTheme = getInitialTheme();
+  document.documentElement.dataset.theme = initialTheme;
+  window.localStorage.setItem('apgms-theme', initialTheme);
+}
 
 const rootElement = document.getElementById('root');
 
@@ -14,7 +25,15 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <Routes>
+        <Route path="/" element={<AppShell />}>
+          <Route index element={<Obligations />} />
+          <Route path="paygw" element={<PAYGW />} />
+          <Route path="gst" element={<GST />} />
+          <Route path="compliance" element={<Compliance />} />
+          <Route path="security" element={<Security />} />
+        </Route>
+      </Routes>
     </BrowserRouter>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/webapp/src/pages/Compliance.tsx
+++ b/webapp/src/pages/Compliance.tsx
@@ -1,0 +1,11 @@
+export default function Compliance() {
+  return (
+    <section>
+      <h1>Compliance</h1>
+      <p>
+        Audit workflows, assign ownership, and evidence completion across the full compliance
+        lifecycle.
+      </p>
+    </section>
+  );
+}

--- a/webapp/src/pages/GST.tsx
+++ b/webapp/src/pages/GST.tsx
@@ -1,0 +1,11 @@
+export default function GST() {
+  return (
+    <section>
+      <h1>GST</h1>
+      <p>
+        Monitor business activity statement preparation, reconcile lodgements, and surface
+        anomalies before submission.
+      </p>
+    </section>
+  );
+}

--- a/webapp/src/pages/Obligations.tsx
+++ b/webapp/src/pages/Obligations.tsx
@@ -1,0 +1,11 @@
+export default function Obligations() {
+  return (
+    <section>
+      <h1>Obligations overview</h1>
+      <p>
+        Track and manage upcoming lodgements, payments, and regulatory commitments from a
+        single workspace.
+      </p>
+    </section>
+  );
+}

--- a/webapp/src/pages/PAYGW.tsx
+++ b/webapp/src/pages/PAYGW.tsx
@@ -1,0 +1,11 @@
+export default function PAYGW() {
+  return (
+    <section>
+      <h1>PAYGW</h1>
+      <p>
+        Review withholding schedules, payroll tax settings, and upcoming payment due dates for
+        every entity.
+      </p>
+    </section>
+  );
+}

--- a/webapp/src/pages/Security.tsx
+++ b/webapp/src/pages/Security.tsx
@@ -1,0 +1,11 @@
+export default function Security() {
+  return (
+    <section>
+      <h1>Security</h1>
+      <p>
+        Surface vulnerabilities, monitor remediation progress, and share evidence of controls with
+        stakeholders.
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an AppShell layout with responsive navigation and theme toggle persistence
- create placeholder pages for key obligation areas with accessible headings
- update routing to nest pages under the new shell and hydrate the saved theme on load

## Testing
- pnpm --filter @apgms/webapp build

------
https://chatgpt.com/codex/tasks/task_e_68f768748e6c8327be9a3fb79767e385