### PR TITLE
Add readiness endpoint, metrics, and graceful shutdown

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "tsx --test test/privacy.spec.ts"
+    "test": "tsx --test test/privacy.spec.ts test/ready.spec.ts test/metrics.spec.ts test/shutdown.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -8,8 +8,11 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import { createApp } from "./app";
+import { setupSignalHandlers } from "./shutdown";
 
 const app = await createApp();
+
+setupSignalHandlers(app);
 
 app.ready(() => {
   app.log.info(app.printRoutes());
@@ -18,8 +21,13 @@ app.ready(() => {
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    void app.close().catch((closeErr) => {
+      app.log.error({ err: closeErr }, "failed to close app after listen error");
+    });
+    process.exit(1);
+  });
 

--- a/services/api-gateway/src/metrics.ts
+++ b/services/api-gateway/src/metrics.ts
@@ -1,0 +1,29 @@
+import { Counter, Histogram, Registry, collectDefaultMetrics } from "./vendor/prom-client";
+
+export interface Metrics {
+  register: Registry;
+  httpRequestsTotal: Counter;
+  httpRequestDurationSeconds: Histogram;
+}
+
+export function createMetrics(): Metrics {
+  const register = new Registry();
+  collectDefaultMetrics();
+
+  const httpRequestsTotal = new Counter({
+    name: "http_requests_total",
+    help: "Total number of HTTP requests",
+    labelNames: ["method", "route", "status_code"],
+    registers: [register],
+  });
+
+  const httpRequestDurationSeconds = new Histogram({
+    name: "http_request_duration_seconds",
+    help: "Duration of HTTP requests in seconds",
+    labelNames: ["method", "route", "status_code"],
+    registers: [register],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  });
+
+  return { register, httpRequestsTotal, httpRequestDurationSeconds };
+}

--- a/services/api-gateway/src/shutdown.ts
+++ b/services/api-gateway/src/shutdown.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from "fastify";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface ShutdownOptions {
+  timeoutMs?: number;
+}
+
+export function setupSignalHandlers(
+  app: FastifyInstance,
+  options: ShutdownOptions = {}
+): () => void {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  const handlers = new Map<NodeJS.Signals, () => void>();
+
+  for (const signal of signals) {
+    const handler = async () => {
+      app.log.info({ signal }, "received shutdown signal");
+      const timeout = setTimeout(() => {
+        app.log.error({ signal }, "shutdown timed out");
+        process.exit(1);
+      }, timeoutMs);
+      if (typeof timeout.unref === "function") {
+        timeout.unref();
+      }
+
+      try {
+        await app.close();
+        clearTimeout(timeout);
+        process.exit(0);
+      } catch (err) {
+        clearTimeout(timeout);
+        app.log.error({ signal, err }, "failed to shutdown cleanly");
+        process.exit(1);
+      }
+    };
+
+    process.once(signal, handler);
+    handlers.set(signal, handler);
+  }
+
+  return () => {
+    for (const [signal, handler] of handlers) {
+      process.removeListener(signal, handler);
+    }
+  };
+}

--- a/services/api-gateway/src/vendor/prom-client.ts
+++ b/services/api-gateway/src/vendor/prom-client.ts
@@ -1,0 +1,183 @@
+export type LabelValues = Record<string, string>;
+
+interface MetricOptions {
+  name: string;
+  help: string;
+  labelNames?: string[];
+  registers?: Registry[];
+}
+
+abstract class MetricBase {
+  protected readonly labelNames: string[];
+  constructor(
+    protected readonly name: string,
+    protected readonly help: string,
+    opts: { labelNames?: string[]; registers?: Registry[] }
+  ) {
+    this.labelNames = opts.labelNames ?? [];
+    for (const register of opts.registers ?? []) {
+      register.registerMetric(this);
+    }
+  }
+
+  abstract reset(): void;
+  abstract snapshot(): string;
+  protected formatLabels(labels: LabelValues): string {
+    if (this.labelNames.length === 0) {
+      return "";
+    }
+    const parts = this.labelNames.map((name) => {
+      const value = labels[name] ?? "";
+      const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+      return `${name}="${escaped}"`;
+    });
+    return `{${parts.join(",")}}`;
+  }
+
+  protected header(type: string): string {
+    return `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} ${type}`;
+  }
+}
+
+export class Counter extends MetricBase {
+  private readonly values = new Map<string, { labels: LabelValues; value: number }>();
+
+  constructor(opts: MetricOptions) {
+    super(opts.name, opts.help, { labelNames: opts.labelNames, registers: opts.registers });
+  }
+
+  inc(labels: LabelValues = {}, value = 1): void {
+    const key = this.createKey(labels);
+    const entry = this.values.get(key);
+    if (entry) {
+      entry.value += value;
+    } else {
+      this.values.set(key, { labels: { ...labels }, value });
+    }
+  }
+
+  reset(): void {
+    this.values.clear();
+  }
+
+  snapshot(): string {
+    const lines = [this.header("counter")];
+    for (const { labels, value } of this.values.values()) {
+      lines.push(`${this.name}${this.formatLabels(labels)} ${value}`);
+    }
+    return lines.join("\n");
+  }
+
+  private createKey(labels: LabelValues): string {
+    return this.labelNames.map((label) => `${label}:${labels[label] ?? ""}`).join("|");
+  }
+}
+
+interface HistogramOptions extends MetricOptions {
+  buckets?: number[];
+}
+
+interface HistogramEntry {
+  labels: LabelValues;
+  bucketCounts: number[];
+  count: number;
+  sum: number;
+}
+
+export class Histogram extends MetricBase {
+  private readonly buckets: number[];
+  private readonly values = new Map<string, HistogramEntry>();
+
+  constructor(opts: HistogramOptions) {
+    super(opts.name, opts.help, { labelNames: opts.labelNames, registers: opts.registers });
+    const provided = opts.buckets ?? [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5];
+    this.buckets = [...provided].sort((a, b) => a - b);
+  }
+
+  observe(labels: LabelValues = {}, value: number): void {
+    const key = this.createKey(labels);
+    let entry = this.values.get(key);
+    if (!entry) {
+      entry = {
+        labels: { ...labels },
+        bucketCounts: new Array(this.buckets.length).fill(0),
+        count: 0,
+        sum: 0,
+      };
+      this.values.set(key, entry);
+    }
+    entry.count += 1;
+    entry.sum += value;
+    for (let i = 0; i < this.buckets.length; i++) {
+      if (value <= this.buckets[i]) {
+        entry.bucketCounts[i] += 1;
+      }
+    }
+  }
+
+  reset(): void {
+    this.values.clear();
+  }
+
+  snapshot(): string {
+    const lines = [this.header("histogram")];
+    for (const { labels, bucketCounts, count, sum } of this.values.values()) {
+      for (let i = 0; i < this.buckets.length; i++) {
+        const le = this.buckets[i];
+        const leLabel = `${this.formatLabels({ ...labels, le: formatBucket(le) })}`;
+        const cumulative = bucketCounts[i];
+        lines.push(`${this.name}_bucket${leLabel} ${cumulative}`);
+      }
+      const infLabel = `${this.formatLabels({ ...labels, le: "+Inf" })}`;
+      lines.push(`${this.name}_bucket${infLabel} ${count}`);
+      lines.push(`${this.name}_sum${this.formatLabels(labels)} ${sum}`);
+      lines.push(`${this.name}_count${this.formatLabels(labels)} ${count}`);
+    }
+    return lines.join("\n");
+  }
+
+  private createKey(labels: LabelValues): string {
+    return this.labelNames.map((label) => `${label}:${labels[label] ?? ""}`).join("|");
+  }
+}
+
+function formatBucket(value: number): string {
+  if (Number.isFinite(value)) {
+    return Number(value).toString();
+  }
+  return "+Inf";
+}
+
+export class Registry {
+  private readonly entries = new Set<MetricBase>();
+  readonly contentType = "text/plain; version=0.0.4; charset=utf-8";
+
+  registerMetric(metric: MetricBase): void {
+    this.entries.add(metric);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  resetMetrics(): void {
+    for (const metric of this.entries) {
+      metric.reset();
+    }
+  }
+
+  async metrics(): Promise<string> {
+    if (this.entries.size === 0) {
+      return "";
+    }
+    const parts = [] as string[];
+    for (const metric of this.entries) {
+      parts.push(metric.snapshot());
+    }
+    return parts.join("\n\n") + "\n";
+  }
+}
+
+export function collectDefaultMetrics(): void {
+  // No-op in the lightweight implementation.
+}

--- a/services/api-gateway/test/metrics.spec.ts
+++ b/services/api-gateway/test/metrics.spec.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import type { FastifyInstance } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+
+import { createApp } from "../src/app";
+
+type MetricsStub = {
+  client: PrismaClient;
+};
+
+function createMetricsStub(): MetricsStub {
+  const prisma = {
+    $queryRaw: async () => 1,
+    $disconnect: async () => {},
+    org: { findUnique: async () => null, update: async () => null },
+    user: { findMany: async () => [], deleteMany: async () => ({ count: 0 }) },
+    bankLine: {
+      findMany: async () => [],
+      create: async () => ({
+        id: "line",
+        orgId: "",
+        date: new Date(),
+        amount: 0,
+        payee: "",
+        desc: "",
+        createdAt: new Date(),
+      }),
+      deleteMany: async () => ({ count: 0 }),
+    },
+    orgTombstone: { create: async () => ({}) },
+    $transaction: async <T>(callback: (tx: unknown) => Promise<T>) => callback(prisma),
+  } as unknown as PrismaClient;
+
+  return { client: prisma };
+}
+
+let app: FastifyInstance;
+
+afterEach(async () => {
+  if (app) {
+    await app.close();
+  }
+});
+
+test("/metrics returns counters and histograms per route", async () => {
+  const stub = createMetricsStub();
+  app = await createApp({ prisma: stub.client });
+  await app.ready();
+
+  const healthResponse = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(healthResponse.statusCode, 200);
+
+  const metricsResponse = await app.inject({ method: "GET", url: "/metrics" });
+  assert.equal(metricsResponse.statusCode, 200);
+  assert.equal(metricsResponse.headers["content-type"], "text/plain; version=0.0.4; charset=utf-8");
+  const body = metricsResponse.body;
+  assert.ok(body.includes('http_requests_total{method="GET",route="/health",status_code="200"} 1'));
+  assert.ok(body.includes("http_request_duration_seconds_bucket"));
+  assert.ok(body.includes('http_request_duration_seconds_count{method="GET",route="/health",status_code="200"} 1'));
+});

--- a/services/api-gateway/test/privacy.spec.ts
+++ b/services/api-gateway/test/privacy.spec.ts
@@ -208,6 +208,8 @@ function createPrismaStub(initial?: Partial<State>): Stub {
     $transaction: async <T>(callback: TransactionCallback<T>) => {
       return callback(client);
     },
+    $queryRaw: async () => 1,
+    $disconnect: async () => {},
   } as unknown as PrismaLike;
 
   return { client, state };

--- a/services/api-gateway/test/ready.spec.ts
+++ b/services/api-gateway/test/ready.spec.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import type { FastifyInstance } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+
+import { createApp } from "../src/app";
+
+type ReadyStubOptions = {
+  healthy: boolean;
+};
+
+type ReadyStub = {
+  client: PrismaClient;
+};
+
+function createReadyStub(options: ReadyStubOptions): ReadyStub {
+  const prisma = {
+    $queryRaw: async () => {
+      if (!options.healthy) {
+        throw new Error("db unavailable");
+      }
+      return 1;
+    },
+    $disconnect: async () => {},
+    org: { findUnique: async () => null, update: async () => null },
+    user: { findMany: async () => [], deleteMany: async () => ({ count: 0 }) },
+    bankLine: {
+      findMany: async () => [],
+      create: async () => ({
+        id: "line",
+        orgId: "",
+        date: new Date(),
+        amount: 0,
+        payee: "",
+        desc: "",
+        createdAt: new Date(),
+      }),
+      deleteMany: async () => ({ count: 0 }),
+    },
+    orgTombstone: { create: async () => ({}) },
+    $transaction: async <T>(callback: (tx: unknown) => Promise<T>) => callback(prisma),
+  } as unknown as PrismaClient;
+
+  return { client: prisma };
+}
+
+let app: FastifyInstance;
+
+afterEach(async () => {
+  if (app) {
+    await app.close();
+  }
+});
+
+test("GET /ready returns 200 when the database is reachable", async () => {
+  const stub = createReadyStub({ healthy: true });
+  app = await createApp({ prisma: stub.client });
+  await app.ready();
+
+  const response = await app.inject({ method: "GET", url: "/ready" });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { ok: true });
+});
+
+test("GET /ready returns 503 when the database is unavailable", async () => {
+  const stub = createReadyStub({ healthy: false });
+  app = await createApp({ prisma: stub.client });
+  await app.ready();
+
+  const response = await app.inject({ method: "GET", url: "/ready" });
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), { ok: false });
+});

--- a/services/api-gateway/test/shutdown.spec.ts
+++ b/services/api-gateway/test/shutdown.spec.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { FastifyInstance } from "fastify";
+
+import { setupSignalHandlers } from "../src/shutdown";
+
+test("setupSignalHandlers gracefully shuts down on SIGTERM", async () => {
+  let closed = false;
+  const app = {
+    close: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      closed = true;
+    },
+    log: {
+      info: () => {},
+      error: () => {},
+    },
+  } as unknown as FastifyInstance;
+
+  const originalExit = process.exit;
+  const exitCalls: Array<number | undefined> = [];
+  (process as any).exit = (code?: number) => {
+    exitCalls.push(code);
+    return undefined as never;
+  };
+
+  const cleanup = setupSignalHandlers(app, { timeoutMs: 50 });
+
+  try {
+    process.emit("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(closed, true);
+    assert.deepEqual(exitCalls, [0]);
+  } finally {
+    cleanup();
+    (process as any).exit = originalExit;
+  }
+});


### PR DESCRIPTION
## Summary
- add Fastify instrumentation backed by a lightweight prom-client implementation and expose `/metrics`
- implement `/ready` to verify database connectivity and close Prisma during app shutdown
- install signal handlers to perform graceful shutdown and cover the new behaviour with tests

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f6580dadf08327b6e9d745e983031e