### PR TITLE
fix: restore admin data routes with jwt auth

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "tsx --test test/privacy.spec.ts"
+    "test": "tsx --test test/privacy.spec.ts test/admin.data.delete.spec.ts test/admin.data.export.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/services/api-gateway/src/schemas/admin.data.ts
+++ b/services/api-gateway/src/schemas/admin.data.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-<<<<<<< HEAD
 export const adminDataDeleteRequestSchema = z.object({
   orgId: z.string().min(1, "orgId is required"),
   email: z.string().email("email must be valid"),
@@ -17,9 +16,6 @@ export const adminDataDeleteResponseSchema = z.object({
     }),
 });
 
-export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
-export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
-=======
 export const subjectDataExportRequestSchema = z.object({
   orgId: z.string().min(1),
   email: z.string().email(),
@@ -44,14 +40,14 @@ export const subjectDataExportResponseSchema = z.object({
   org: orgSchema,
   user: userSchema,
   relationships: relationshipsSchema,
-  exportedAt: z.string(),
+  exportedAt: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), {
+      message: "exportedAt must be ISO string",
+    }),
 });
 
-export type SubjectDataExportRequest = z.infer<
-  typeof subjectDataExportRequestSchema
->;
-
-export type SubjectDataExportResponse = z.infer<
-  typeof subjectDataExportResponseSchema
->;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
+export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
+export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
+export type SubjectDataExportRequest = z.infer<typeof subjectDataExportRequestSchema>;
+export type SubjectDataExportResponse = z.infer<typeof subjectDataExportResponseSchema>;


### PR DESCRIPTION
## Summary
- merge the admin data delete and export routes behind JWT-based admin authentication
- provide shared zod schemas for both delete and export payloads
- refresh admin data tests to use signed JWTs and ensure the service test command runs every spec

## Testing
- pnpm -r typecheck
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f657ed37748327923c694d11324f44