### PR TITLE
Add security documentation and configure dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/docs/security/ASVS-mapping.md
+++ b/docs/security/ASVS-mapping.md
@@ -1,1 +1,13 @@
-﻿# OWASP ASVS L2
+# OWASP ASVS L2
+
+The table below tracks how the platform satisfies priority Application Security Verification Standard (ASVS) Level 2 controls. Each row links the control to the engineering artefact that demonstrates coverage today and highlights upcoming work to close any gaps.
+
+| Control | Current | Planned | Evidence (file:line / workflow) |
+| --- | --- | --- | --- |
+| V2.1.1 – Enforce authenticated access to administrative functions | Administrative routes verify an `x-admin-token` header before servicing export or deletion requests. | Replace static admin token with signed service-to-service credentials issued by IAM. | `services/api-gateway/src/app.ts:109-189` |
+| V3.3.1 – Protect sensitive identifiers in transit and at rest | TFNs are tokenised and encrypted using AES-256-GCM with audit logging hooks. | Automate KMS key rotation and publish audit metrics to the security dashboard. | `services/api-gateway/src/lib/pii.ts:1-120` |
+| V5.1.2 – Validate and constrain inbound data payloads | JSON schemas constrain PII fields such as ABN and TFN token formats for connector ingestion. | Extend schema validation to all connector payloads and enforce with contract tests. | `services/api-gateway/src/schemas/pii.schema.json:1-28` |
+| V7.2.3 – Log security-sensitive events with tamper resistance | The PII decrypt endpoint emits structured `security_event` logs through the Fastify logger integration. | Ship security logs to the central SIEM with immutability controls enabled. | `services/api-gateway/src/lib/pii.ts:63-108` |
+| V14.2.3 – Maintain dependency hygiene with automated updates | Weekly dependency update checks cover npm packages and GitHub Actions. | Add alert routing to #sec-alerts and auto-merge policies for patch-level updates. | `.github/dependabot.yml` |
+
+_Last reviewed: {{< today >}}_

--- a/docs/security/TFN-SOP.md
+++ b/docs/security/TFN-SOP.md
@@ -1,1 +1,51 @@
-﻿# TFN handling SOP
+# TFN handling SOP
+
+This standard operating procedure (SOP) defines how Australian Tax File Numbers (TFNs) are collected, stored, retained, and deleted across the APGMS platform. It aligns with OAIC guidance and supports downstream compliance artefacts such as the ASVS mapping and incident playbooks.
+
+## 1. Scope and principles
+
+- Applies to any service that processes identifiers used for tax reporting, including TFNs and derived tokens.
+- All access is restricted to authenticated administrators and is logged as a security event.
+- Raw TFNs must never be persisted or transmitted in plain text outside of a secure, point-in-time workflow.
+
+## 2. Collection
+
+1. TFNs are collected only during onboarding or mandated verification flows that originate in the admin console.
+2. The admin console posts TFNs directly to the API Gateway `/admin/pii/decrypt` handler, which immediately tokenises the value via `tokenizeTFN`. No client-side caching is permitted.
+3. Requests must include a valid admin bearer token (`x-admin-token`) and originate from the privileged network segment.
+
+## 3. Storage and protection
+
+- TFNs are transformed into deterministic tokens using HMAC salts and encrypted with AES-256-GCM before being stored. See `services/api-gateway/src/lib/pii.ts` for the implementation.
+- Encryption keys and salts are injected at runtime; the materials are sourced from the secrets manager and rotated according to the key management policy.
+- Audit hooks record every decrypt or tokenisation event, enabling forensic traceability.
+
+## 4. Retention and minimisation
+
+- TFN tokens live only as long as the associated organisation remains active. Linked records (users, bank lines) are deleted when an organisation is deactivated.
+- Tombstoned payloads are retained in the `orgTombstone` table solely for legal traceability and include the deletion timestamp. Access requires the same administrative token as live data.
+- Quarterly reviews ensure no TFN-derived fields exist outside sanctioned tables.
+
+## 5. Export and deletion runbook
+
+Follow these steps when fulfilling a subject right or regulator request. The flows rely on the admin data routes exposed by the API Gateway.
+
+### 5.1 Export
+
+1. Authenticate to the admin console with an account in the security group.
+2. Issue a `GET /admin/export/:orgId` request with the `x-admin-token` header set.
+3. Verify the JSON payload and store it in the encrypted evidence bucket. Notify the requester via the secure channel.
+
+### 5.2 Deletion
+
+1. Confirm the request is authorised (legal ticket + incident commander approval).
+2. Issue a `DELETE /admin/delete/:orgId` call with the `x-admin-token` header.
+3. Capture the resulting `security_event` log entry and archive it with the case notes.
+4. Update the TFN retention register and close the request.
+
+## 6. Exceptions and escalation
+
+- Any deviation must be approved by the CISO and recorded in the risk register.
+- Suspected exposure or unauthorised access triggers the Notifiable Data Breach runbook (`runbooks/ndb.md`).
+
+_Last reviewed: {{< today >}}_

--- a/status/README.md
+++ b/status/README.md
@@ -1,1 +1,42 @@
-﻿# Status site
+# Status site
+
+This directory houses the tooling and content used for public incident communications. The playbook below explains how to coordinate updates when a production issue occurs.
+
+## Incident playbook
+
+1. **Triage (0-5 minutes)**
+   - On-call engineer confirms the impact and opens an incident thread in `#inc-status`.
+   - Assign roles: incident commander (IC), communications lead (CL), and operations lead (OL).
+2. **Assess (5-15 minutes)**
+   - IC captures scope, customer impact, and mitigation steps in the shared timeline doc.
+   - OL validates monitoring dashboards and collects supporting metrics.
+   - CL drafts the initial status page entry using the template in `artifacts/status-template.md`.
+3. **Communicate (within 15 minutes of declaration)**
+   - Publish the first public update (see posting workflow below).
+   - Update internal stakeholders in `#eng-leads` and create a Jira incident ticket.
+4. **Stabilise**
+   - OL drives remediation while IC ensures updates are posted at least every 30 minutes.
+   - CL records customer comms questions and escalates blockers to the IC.
+5. **Resolve**
+   - When service is restored, IC confirms with OL and CL before publishing the recovery update.
+   - Schedule the post-incident review within 48 hours and link artifacts in the Jira ticket.
+
+Escalations that involve potential data exposure must additionally follow the [Notifiable Data Breach runbook](../runbooks/ndb.md).
+
+## Status page posting workflow
+
+- **Who posts?** The communications lead (CL) is the only person authorised to publish updates. Backup is the on-call product manager if the CL is unavailable.
+- **When to post?**
+  - Initial update within 15 minutes of incident declaration.
+  - Follow-up updates every 30 minutes while impact continues.
+  - Resolution update within 15 minutes of confirming recovery.
+- **How to post?**
+  1. CL runs `pnpm --filter status deploy` from the repository root to open the publisher prompt.
+  2. Enter the prepared message, ensuring it covers impact, scope, mitigation, and next update time.
+  3. Verify the rendered preview locally (`pnpm --filter status preview`) before confirming publish.
+  4. After publishing, drop the permalink in `#inc-status` and update the incident ticket.
+- **Change control**
+  - Emergency updates do not require CAB approval but must be retrospectively logged in the change register.
+  - Post-incident, archive the final content in the incident knowledge base for auditing.
+
+_Last reviewed: {{< today >}}_


### PR DESCRIPTION
## Summary
- expand the ASVS mapping with current controls, planned improvements, and evidence links
- document the TFN handling SOP covering collection, storage, retention, and admin workflows
- add an incident communications playbook for the status site and configure dependabot for weekly updates

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f650fd75788327ab6698c642ee6649