### PR TITLE
Add CSP meta tag and enhance Playwright CI configuration

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,11 +5,13 @@ const testDir = path.join(__dirname, 'webapp', 'tests');
 
 export default defineConfig({
   testDir,
+  forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   timeout: 60_000,
   expect: {
     timeout: 10_000
   },
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173',
     trace: 'on-first-retry'

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; block-all-mixed-content; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests"
+    />
     <title>APGMS Pro+</title>
   </head>
   <body>

--- a/webapp/tests/home-accessibility.spec.ts
+++ b/webapp/tests/home-accessibility.spec.ts
@@ -1,0 +1,13 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test.describe('Home page accessibility', () => {
+  test('has no detectable accessibility violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    expect(results.violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Content Security Policy meta tag that mirrors the server’s Helmet directives in the HTML entrypoint
- tune the Playwright configuration for CI-friendly defaults and reporting
- add a focused home page accessibility test that asserts zero axe-core violations

## Testing
- pnpm --filter @apgms/webapp test *(fails: Playwright browsers are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f650ea8a08832798e674350256a898