### PR TITLE
Add strict CORS allowlist and CSP protections

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Keep this CSP in sync with services/api-gateway/src/app.ts (connect-src must reflect CORS_ALLOWLIST) -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self'; frame-ancestors 'none'; script-src 'self' 'nonce-__GENERATED_AT_RUNTIME__'; style-src 'self' 'unsafe-inline'"
+    />
     <title>APGMS Pro+</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- enforce an origin allowlist derived from `CORS_ALLOWLIST` and reject requests from other origins with 403s
- register Helmet with a CSP that issues per-request script nonces and mirrors the allowlisted origins
- document the CSP in the SPA entrypoint so it stays aligned with the gateway configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f649b9c5dc8327ba5ee9cc767f3e8e