### PR TITLE
Update CI workflow paths and add security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,17 @@ name: CI
 
 on: [push, pull_request]
 
-defaults:
-  run:
-    working-directory: apgms
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check for merge conflict markers
+        run: |
+          if git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!*.lock'; then
+            echo 'Error: merge conflict markers detected.'
+            exit 1
+          fi
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -18,8 +20,8 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-          cache-dependency-path: apgms/pnpm-lock.yaml
-      - run: pnpm install
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps
       - run: pnpm -r build
       - run: pnpm -r test
@@ -29,6 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check for merge conflict markers
+        run: |
+          if git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!*.lock'; then
+            echo 'Error: merge conflict markers detected.'
+            exit 1
+          fi
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -36,8 +44,8 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-          cache-dependency-path: apgms/pnpm-lock.yaml
-      - run: pnpm install
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps
       - run: pnpm --filter @apgms/webapp test:axe
 
@@ -46,6 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check for merge conflict markers
+        run: |
+          if git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!*.lock'; then
+            echo 'Error: merge conflict markers detected.'
+            exit 1
+          fi
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -53,12 +67,12 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-          cache-dependency-path: apgms/pnpm-lock.yaml
-      - run: pnpm install
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @apgms/webapp build
       - name: Lighthouse CI
         uses: treosh/lighthouse-ci-action@v10
         with:
-          configPath: ./apgms/lighthouserc.json
+          configPath: ./lighthouserc.json
           runs: 1
           uploadArtifacts: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,59 @@
-﻿name: Security
+name: Security
+
 on: [push]
+
 jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo scanning
+      - name: Check for merge conflict markers
+        run: |
+          if git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!*.lock'; then
+            echo 'Error: merge conflict markers detected.'
+            exit 1
+          fi
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p sbom
+          pnpm dlx @cyclonedx/cyclonedx-npm \
+            --ignore-npm-errors \
+            --fail-on-error \
+            --spec-version 1.5 \
+            --output-format json \
+            --output-file sbom/bom.json
+          pnpm dlx @cyclonedx/cyclonedx-npm \
+            --ignore-npm-errors \
+            --fail-on-error \
+            --spec-version 1.5 \
+            --output-format xml \
+            --output-file sbom/bom.xml
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom
+      - name: pnpm audit
+        run: pnpm audit --prod --audit-level=high
+      - name: Gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --no-banner --redact
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.20.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+          exit-code: '1'


### PR DESCRIPTION
## Summary
- run pnpm install/build/test from the repository root and guard against merge conflict markers in CI jobs
- ensure accessibility and lighthouse checks use the frozen lockfile and correct config path
- add a security workflow that produces a CycloneDX SBOM, runs pnpm audit, and executes gitleaks and trivy scans

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f649c6865483278ff2aad49153c099