### PR TITLE
Add validation and idempotency for bank line API

### DIFF
--- a/services/api-gateway/src/schemas/bank-lines.ts
+++ b/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const isoDateString = z
+  .string()
+  .min(1, "date is required")
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "date must be an ISO 8601 string",
+  });
+
+export const bankLineQuerySchema = z.object({
+  take: z.coerce.number().int().min(1).max(200).default(20),
+  from: isoDateString.optional(),
+  to: isoDateString.optional(),
+});
+
+export const createBankLineSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  amount: z.coerce.number().finite("amount must be a finite number"),
+  date: isoDateString,
+  memo: z.string().max(1024, "memo must be 1024 characters or fewer").optional(),
+});
+
+export type BankLineQuery = z.infer<typeof bankLineQuerySchema>;
+export type CreateBankLineInput = z.infer<typeof createBankLineSchema>;


### PR DESCRIPTION
## Summary
- add Zod schemas for bank line queries and creation payloads
- validate GET filters and enforce idempotent POST handling backed by a 24h cache
- expand test coverage to exercise validation errors and idempotency responses

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f649aab4ac8327852d1d2e8933cce9