### PR TITLE
Add CSP protections and restrict API gateway CORS

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "^12.0.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Keep this CSP in sync with services/api-gateway/src/app.ts -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self'; script-src 'self' 'nonce-__NONCE__'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'"
+    />
     <title>APGMS Pro+</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- load the CORS allowlist from `CORS_ALLOWLIST` and reject disallowed origins with a JSON 403
- register `@fastify/helmet` with a per-request nonce and CSP directives covering scripts, styles, frames, and connect targets
- document the CSP for the SPA shell so it stays in sync with the API gateway configuration

## Testing
- pnpm --filter @apgms/api-gateway test *(fails: missing @fastify/helmet because the registry is inaccessible in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6426438948327915cf31d225b4536