### PR TITLE
Secure /users & /bank-lines with AuthZ, validation, idempotency

### DIFF
--- a/services/api-gateway/src/app.ts
+++ b/services/api-gateway/src/app.ts
@@ -1,10 +1,30 @@
+import { createHash, createPublicKey, createVerify } from "node:crypto";
+
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
 import type { Org, User, BankLine, PrismaClient } from "@prisma/client";
 
 import { maskError, maskObject } from "@apgms/shared";
+import { bankLinesQuerySchema, createBankLineSchema } from "./schemas/bank-lines";
+import { redactEmailIfNeeded } from "./lib/pii";
 
 const ADMIN_HEADER = "x-admin-token";
+const API_KEY_HEADER = "x-api-key";
+const ORG_HEADER = "x-org-id";
+const USER_ROLE_HEADER = "x-user-role";
+const IDEMPOTENCY_HEADER = "idempotency-key";
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+
+type AuthenticatedUser = {
+  orgId: string;
+  role: string;
+};
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user?: AuthenticatedUser;
+  }
+}
 
 export interface CreateAppOptions {
   prisma?: PrismaClient;
@@ -45,6 +65,264 @@ type PrismaLike = Pick<
 
 let cachedPrisma: PrismaClient | null = null;
 
+interface IdempotencyRecord {
+  hash: string;
+  statusCode: number;
+  body: unknown;
+  expiresAt: number;
+}
+
+function createIdempotencyStore() {
+  const store = new Map<string, IdempotencyRecord>();
+
+  return {
+    get(key: string): IdempotencyRecord | undefined {
+      const entry = store.get(key);
+      if (!entry) {
+        return undefined;
+      }
+      if (entry.expiresAt <= Date.now()) {
+        store.delete(key);
+        return undefined;
+      }
+      return entry;
+    },
+    set(key: string, value: IdempotencyRecord): void {
+      store.set(key, value);
+    },
+  };
+}
+
+function getHeaderValue(request: FastifyRequest, header: string): string | undefined {
+  const raw = request.headers[header] ?? request.headers[header.toLowerCase() as keyof typeof request.headers];
+  if (!raw) {
+    return undefined;
+  }
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+function stableHashPayload(payload: unknown): string {
+  const stable = JSON.stringify(sortPayload(payload));
+  return createHash("sha256").update(stable).digest("hex");
+}
+
+function sortPayload(payload: unknown): unknown {
+  if (Array.isArray(payload)) {
+    return payload.map((item) => sortPayload(item));
+  }
+  if (payload && typeof payload === "object") {
+    const entries = Object.entries(payload as Record<string, unknown>)
+      .map(([key, value]) => [key, sortPayload(value)] as const)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return Object.fromEntries(entries);
+  }
+  return payload;
+}
+
+type DecodedJwtPayload = {
+  aud?: string | string[];
+  iss?: string;
+  exp?: number;
+  nbf?: number;
+  scope?: string | string[];
+  [key: string]: unknown;
+};
+
+type DecodedJwtHeader = {
+  alg?: string;
+  kid?: string;
+  [key: string]: unknown;
+};
+
+interface ParsedJwt {
+  header: DecodedJwtHeader;
+  payload: DecodedJwtPayload;
+  signature: Buffer;
+  signingInput: string;
+}
+
+interface JwksCacheEntry {
+  keys: JsonWebKey[];
+  fetchedAt: number;
+}
+
+const jwksCache = new Map<string, JwksCacheEntry>();
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+function extractClaim(payload: DecodedJwtPayload, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function createAuthPreHandler(): (request: FastifyRequest, reply: FastifyReply) => Promise<void> {
+  const apiKey = process.env.API_KEY;
+  const apiKeyOrgId = process.env.API_KEY_ORG_ID;
+  const apiKeyRole = process.env.API_KEY_ROLE ?? "admin";
+
+  const jwksUrl = process.env.AUTH_JWKS_URL;
+  const audience = process.env.AUTH_AUDIENCE;
+  const issuer = process.env.AUTH_ISSUER;
+
+  return async (request, reply) => {
+    const authHeader = getHeaderValue(request, "authorization");
+    const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
+
+    if (bearerToken && jwksUrl && audience && issuer) {
+      try {
+        const verified = await verifyJwtToken(bearerToken, jwksUrl, audience, issuer);
+        request.user = verified;
+        return;
+      } catch (error) {
+        request.log.warn({ err: maskError(error) }, "jwt verification failed");
+        return void reply.code(401).send({ error: "unauthorized" });
+      }
+    }
+
+    if (apiKey) {
+      const providedKey = getHeaderValue(request, API_KEY_HEADER);
+      if (providedKey && providedKey === apiKey) {
+        const orgId = getHeaderValue(request, ORG_HEADER) ?? apiKeyOrgId;
+        if (!orgId) {
+          return void reply.code(401).send({ error: "unauthorized" });
+        }
+        const role = getHeaderValue(request, USER_ROLE_HEADER) ?? apiKeyRole;
+        request.user = { orgId, role };
+        return;
+      }
+    }
+
+    return void reply.code(401).send({ error: "unauthorized" });
+  };
+}
+
+async function verifyJwtToken(
+  token: string,
+  jwksUrl: string,
+  audience: string,
+  issuer: string,
+): Promise<AuthenticatedUser> {
+  const parsed = parseJwt(token);
+  if (parsed.header.alg !== "RS256") {
+    throw new Error("unsupported_algorithm");
+  }
+  const jwk = await selectJwk(jwksUrl, parsed.header.kid);
+  if (!jwk) {
+    throw new Error("jwk_not_found");
+  }
+
+  const keyObject = createPublicKey({ key: jwk, format: "jwk" });
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(parsed.signingInput);
+  verifier.end();
+  const validSignature = verifier.verify(keyObject, parsed.signature);
+  if (!validSignature) {
+    throw new Error("invalid_signature");
+  }
+
+  if (!validateAudience(parsed.payload.aud, audience)) {
+    throw new Error("invalid_audience");
+  }
+  if (parsed.payload.iss !== issuer) {
+    throw new Error("invalid_issuer");
+  }
+  if (!validateTokenTiming(parsed.payload)) {
+    throw new Error("token_not_current");
+  }
+
+  const orgId =
+    extractClaim(parsed.payload, ["orgId", "org_id", "https://apgms.io/orgId", "https://apgms.io/org_id"]) ?? undefined;
+  if (!orgId) {
+    throw new Error("missing_org_id");
+  }
+  const role =
+    extractClaim(parsed.payload, ["role", "https://apgms.io/role"]) ?? deriveRoleFromScope(parsed.payload.scope);
+
+  return { orgId, role };
+}
+
+function deriveRoleFromScope(scope: DecodedJwtPayload["scope"]): string {
+  if (typeof scope === "string") {
+    const parts = scope.split(" ").filter(Boolean);
+    if (parts.length > 0) {
+      return parts[0];
+    }
+  }
+  if (Array.isArray(scope) && typeof scope[0] === "string") {
+    return scope[0];
+  }
+  return "user";
+}
+
+function validateAudience(aud: DecodedJwtPayload["aud"], expected: string): boolean {
+  if (typeof aud === "string") {
+    return aud === expected;
+  }
+  if (Array.isArray(aud)) {
+    return aud.includes(expected);
+  }
+  return false;
+}
+
+function validateTokenTiming(payload: DecodedJwtPayload): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp === "number" && now >= payload.exp) {
+    return false;
+  }
+  if (typeof payload.nbf === "number" && now < payload.nbf) {
+    return false;
+  }
+  return true;
+}
+
+async function selectJwk(jwksUrl: string, kid?: string): Promise<JsonWebKey | undefined> {
+  const keys = await loadJwks(jwksUrl);
+  return keys.find((key) => key.kty === "RSA" && (!kid || key.kid === kid));
+}
+
+async function loadJwks(jwksUrl: string): Promise<JsonWebKey[]> {
+  const cached = jwksCache.get(jwksUrl);
+  if (cached && Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return cached.keys;
+  }
+
+  const response = await fetch(jwksUrl);
+  if (!response.ok) {
+    throw new Error(`failed_to_fetch_jwks:${response.status}`);
+  }
+  const body = (await response.json()) as { keys?: JsonWebKey[] };
+  if (!Array.isArray(body.keys)) {
+    throw new Error("jwks_missing_keys");
+  }
+  jwksCache.set(jwksUrl, { keys: body.keys, fetchedAt: Date.now() });
+  return body.keys;
+}
+
+function parseJwt(token: string): ParsedJwt {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("invalid_jwt_format");
+  }
+  const header = JSON.parse(base64UrlDecode(parts[0]).toString("utf8")) as DecodedJwtHeader;
+  const payload = JSON.parse(base64UrlDecode(parts[1]).toString("utf8")) as DecodedJwtPayload;
+  const signature = base64UrlDecode(parts[2]);
+  const signingInput = `${parts[0]}.${parts[1]}`;
+  return { header, payload, signature, signingInput };
+}
+
+function base64UrlDecode(segment: string): Buffer {
+  let normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  if (padding > 0) {
+    normalized += "=".repeat(4 - padding);
+  }
+  return Buffer.from(normalized, "base64");
+}
+
 async function loadDefaultPrisma(): Promise<PrismaLike> {
   if (!cachedPrisma) {
     const module = (await import("@apgms/shared/src/db")) as { prisma: PrismaClient };
@@ -57,6 +335,8 @@ export async function createApp(options: CreateAppOptions = {}): Promise<Fastify
   const prisma = (options.prisma as PrismaLike | undefined) ?? (await loadDefaultPrisma());
 
   const app = Fastify({ logger: true });
+  const authPreHandler = createAuthPreHandler();
+  const idempotencyStore = createIdempotencyStore();
 
   app.register(cors, { origin: true });
 
@@ -64,42 +344,88 @@ export async function createApp(options: CreateAppOptions = {}): Promise<Fastify
 
   app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-  app.get("/users", async () => {
+  app.get("/users", { preHandler: authPreHandler }, async (req) => {
+    const authUser = req.user!;
     const users = await prisma.user.findMany({
       select: { email: true, orgId: true, createdAt: true },
+      where: { orgId: authUser.orgId },
       orderBy: { createdAt: "desc" },
     });
-    return { users };
+    return {
+      users: users.map((user) => ({
+        ...user,
+        email: redactEmailIfNeeded(user.email, authUser.role),
+      })),
+    };
   });
 
-  app.get("/bank-lines", async (req) => {
-    const take = Number((req.query as any).take ?? 20);
+  app.get("/bank-lines", { preHandler: authPreHandler }, async (req) => {
+    const authUser = req.user!;
+    const parsedQuery = bankLinesQuerySchema.parse(req.query ?? {});
+    const where: Record<string, unknown> = { orgId: authUser.orgId };
+    const dateFilters: Record<string, Date> = {};
+    if (parsedQuery.startDate) {
+      dateFilters.gte = new Date(parsedQuery.startDate);
+    }
+    if (parsedQuery.endDate) {
+      dateFilters.lte = new Date(parsedQuery.endDate);
+    }
+    if (Object.keys(dateFilters).length > 0) {
+      where.date = dateFilters;
+    }
+
     const lines = await prisma.bankLine.findMany({
+      where,
       orderBy: { date: "desc" },
-      take: Math.min(Math.max(take, 1), 200),
+      take: parsedQuery.take,
+      skip: parsedQuery.skip,
     });
     return { lines };
   });
 
-  app.post("/bank-lines", async (req, rep) => {
+  app.post("/bank-lines", { preHandler: authPreHandler }, async (req, rep) => {
+    const authUser = req.user!;
+    const idempotencyKey = getHeaderValue(req, IDEMPOTENCY_HEADER);
+    if (!idempotencyKey || idempotencyKey.length > 64) {
+      return rep.code(400).send({ error: "invalid_idempotency_key" });
+    }
+
+    let payload;
     try {
-      const body = req.body as {
-        orgId: string;
-        date: string;
-        amount: number | string;
-        payee: string;
-        desc: string;
-      };
+      payload = createBankLineSchema.parse(req.body ?? {});
+    } catch (error) {
+      req.log.warn({ err: maskError(error) }, "invalid bank line payload");
+      return rep.code(400).send({ error: "bad_request" });
+    }
+
+    const hashedBody = stableHashPayload(payload);
+    const storeKey = `${authUser.orgId}:${idempotencyKey}`;
+    const existing = idempotencyStore.get(storeKey);
+    if (existing) {
+      if (existing.hash !== hashedBody) {
+        return rep.code(409).send({ error: "idempotency_conflict" });
+      }
+      return rep.code(existing.statusCode).send(existing.body);
+    }
+
+    try {
       const created = await prisma.bankLine.create({
         data: {
-          orgId: body.orgId,
-          date: new Date(body.date),
-          amount: body.amount as any,
-          payee: body.payee,
-          desc: body.desc,
+          orgId: authUser.orgId,
+          date: new Date(payload.date),
+          amount: payload.amount as any,
+          payee: payload.memo ?? "N/A",
+          desc: payload.memo ?? "",
         },
       });
-      return rep.code(201).send(created);
+      const responseBody = JSON.parse(JSON.stringify(created));
+      idempotencyStore.set(storeKey, {
+        hash: hashedBody,
+        statusCode: 201,
+        body: responseBody,
+        expiresAt: Date.now() + IDEMPOTENCY_TTL_MS,
+      });
+      return rep.code(201).send(responseBody);
     } catch (e) {
       req.log.error({ err: maskError(e) }, "failed to create bank line");
       return rep.code(400).send({ error: "bad_request" });

--- a/services/api-gateway/src/lib/pii.ts
+++ b/services/api-gateway/src/lib/pii.ts
@@ -145,3 +145,32 @@ export function registerPIIRoutes(app: FastifyInstance, guard: AdminGuard): void
     },
   );
 }
+
+const EMAIL_REDACTION = "***redacted***";
+
+export function redactEmail(email: string): string {
+  if (!email) {
+    return EMAIL_REDACTION;
+  }
+
+  const [local, domain] = email.split("@");
+  if (!domain) {
+    return EMAIL_REDACTION;
+  }
+
+  if (local.length <= 2) {
+    return `${local.charAt(0)}***@${domain}`;
+  }
+
+  const visiblePrefix = local.slice(0, 2);
+  const visibleSuffix = local.slice(-1);
+  const maskedLength = Math.max(3, local.length - 3);
+  return `${visiblePrefix}${"*".repeat(maskedLength)}${visibleSuffix}@${domain}`;
+}
+
+export function redactEmailIfNeeded(email: string, role: string): string {
+  if (role?.toLowerCase() === "admin") {
+    return email;
+  }
+  return redactEmail(email);
+}

--- a/services/api-gateway/src/schemas/bank-lines.ts
+++ b/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const bankLinesQuerySchema = z
+  .object({
+    take: z.coerce.number().int().min(1).max(200).default(20),
+    skip: z.coerce.number().int().min(0).default(0),
+    startDate: z.string().datetime().optional(),
+    endDate: z.string().datetime().optional(),
+  })
+  .partial({ startDate: true, endDate: true });
+
+export type BankLinesQueryInput = z.infer<typeof bankLinesQuerySchema>;
+
+export const createBankLineSchema = z.object({
+  amount: z.coerce.number().finite(),
+  date: z.string().datetime(),
+  memo: z.string().trim().max(1024).optional(),
+});
+
+export type CreateBankLineInput = z.infer<typeof createBankLineSchema>;

--- a/services/api-gateway/test/privacy.spec.ts
+++ b/services/api-gateway/test/privacy.spec.ts
@@ -39,6 +39,12 @@ let stub: Stub;
 
 beforeEach(async () => {
   process.env.ADMIN_TOKEN = ADMIN_TOKEN;
+  process.env.API_KEY = "test-api-key";
+  process.env.API_KEY_ORG_ID = "org-123";
+  process.env.API_KEY_ROLE = "admin";
+  delete process.env.AUTH_JWKS_URL;
+  delete process.env.AUTH_AUDIENCE;
+  delete process.env.AUTH_ISSUER;
   stub = createPrismaStub();
   app = await createApp({ prisma: stub.client as unknown as PrismaClient });
   await app.ready();
@@ -46,6 +52,9 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await app.close();
+  delete process.env.API_KEY;
+  delete process.env.API_KEY_ORG_ID;
+  delete process.env.API_KEY_ROLE;
 });
 
 test("admin export requires a valid admin token", async (t) => {
@@ -117,6 +126,158 @@ test("deleting an organisation soft-deletes data and records a tombstone", async
   assert.ok(tombstone.payload.org.deletedAt && Date.parse(tombstone.payload.org.deletedAt));
 });
 
+test("/users requires authentication", async () => {
+  const response = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(response.statusCode, 401);
+});
+
+test("non-admin users receive redacted emails", async () => {
+  seedOrgWithData(stub.state, {
+    orgId: "org-123",
+    userId: "user-redact",
+    lineId: "line-redact",
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: {
+      "x-api-key": "test-api-key",
+      "x-org-id": "org-123",
+      "x-user-role": "member",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as { users: Array<{ email: string }> };
+  assert.equal(payload.users.length, 1);
+  assert.notEqual(payload.users[0].email, "someone@example.com");
+  assert.ok(payload.users[0].email.includes("***"));
+});
+
+test("admin users can view full emails", async () => {
+  seedOrgWithData(stub.state, {
+    orgId: "org-123",
+    userId: "user-admin",
+    lineId: "line-admin",
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: {
+      "x-api-key": "test-api-key",
+      "x-org-id": "org-123",
+      "x-user-role": "admin",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as { users: Array<{ email: string }> };
+  assert.equal(payload.users[0].email, "someone@example.com");
+});
+
+test("/bank-lines requires authentication", async () => {
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(response.statusCode, 401);
+});
+
+test("bank line queries are scoped to the caller organisation", async () => {
+  const baseDate = new Date("2024-03-01T00:00:00Z");
+  stub.state.orgs.push(
+    { id: "org-123", name: "Primary", createdAt: baseDate, deletedAt: null } as OrgState,
+    { id: "org-999", name: "Other", createdAt: baseDate, deletedAt: null } as OrgState,
+  );
+  stub.state.users.push({
+    id: "user-1",
+    email: "member@example.com",
+    password: "hashed",
+    orgId: "org-123",
+    createdAt: baseDate,
+  } as User);
+  stub.state.bankLines.push(
+    {
+      id: "line-a",
+      orgId: "org-123",
+      date: new Date("2024-03-10T00:00:00Z"),
+      amount: 500 as any,
+      payee: "Vendor",
+      desc: "Invoice",
+      createdAt: baseDate,
+    } as BankLine,
+    {
+      id: "line-b",
+      orgId: "org-999",
+      date: new Date("2024-03-12T00:00:00Z"),
+      amount: 750 as any,
+      payee: "Other",
+      desc: "Other",
+      createdAt: baseDate,
+    } as BankLine,
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/bank-lines?startDate=2024-03-01T00:00:00.000Z",
+    headers: {
+      "x-api-key": "test-api-key",
+      "x-org-id": "org-123",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as { lines: Array<{ id: string; orgId: string }> };
+  assert.equal(payload.lines.length, 1);
+  assert.equal(payload.lines[0].id, "line-a");
+});
+
+test("reusing an idempotency key returns the original response", async () => {
+  stub.state.orgs.push({
+    id: "org-123",
+    name: "Org",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    deletedAt: null,
+  } as OrgState);
+
+  const payload = { amount: 123.45, date: "2024-04-01T00:00:00.000Z", memo: "First" };
+  const headers = {
+    "x-api-key": "test-api-key",
+    "x-org-id": "org-123",
+    "Idempotency-Key": "dup-key",
+  };
+
+  const first = await app.inject({ method: "POST", url: "/bank-lines", headers, payload });
+  assert.equal(first.statusCode, 201);
+  const second = await app.inject({ method: "POST", url: "/bank-lines", headers, payload });
+  assert.equal(second.statusCode, 201);
+  assert.equal(stub.state.bankLines.length, 1);
+  assert.deepEqual(second.json(), first.json());
+});
+
+test("changing the payload with the same idempotency key conflicts", async () => {
+  stub.state.orgs.push({
+    id: "org-123",
+    name: "Org",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    deletedAt: null,
+  } as OrgState);
+
+  const headers = {
+    "x-api-key": "test-api-key",
+    "x-org-id": "org-123",
+    "Idempotency-Key": "conflict-key",
+  };
+
+  const firstPayload = { amount: 10, date: "2024-05-01T00:00:00.000Z", memo: "Initial" };
+  const secondPayload = { amount: 20, date: "2024-05-01T00:00:00.000Z", memo: "Changed" };
+
+  const first = await app.inject({ method: "POST", url: "/bank-lines", headers, payload: firstPayload });
+  assert.equal(first.statusCode, 201);
+  const second = await app.inject({ method: "POST", url: "/bank-lines", headers, payload: secondPayload });
+  assert.equal(second.statusCode, 409);
+  assert.equal(stub.state.bankLines.length, 1);
+});
+
 function createPrismaStub(initial?: Partial<State>): Stub {
   const state: State = {
     orgs: initial?.orgs ?? [],
@@ -147,8 +308,11 @@ function createPrismaStub(initial?: Partial<State>): Stub {
       },
     },
     user: {
-      findMany: async ({ select, orderBy }) => {
+      findMany: async ({ select, orderBy, where }) => {
         let users = [...state.users];
+        if (where?.orgId) {
+          users = users.filter((user) => user.orgId === where.orgId);
+        }
         if (orderBy?.createdAt === "desc") {
           users.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
         }
@@ -164,10 +328,23 @@ function createPrismaStub(initial?: Partial<State>): Stub {
       },
     },
     bankLine: {
-      findMany: async ({ orderBy, take }) => {
+      findMany: async ({ orderBy, take, skip, where }) => {
         let lines = [...state.bankLines];
+        if (where?.orgId) {
+          lines = lines.filter((line) => line.orgId === where.orgId);
+        }
+        const dateFilter = where?.date as { gte?: Date; lte?: Date } | undefined;
+        if (dateFilter?.gte) {
+          lines = lines.filter((line) => line.date >= dateFilter.gte!);
+        }
+        if (dateFilter?.lte) {
+          lines = lines.filter((line) => line.date <= dateFilter.lte!);
+        }
         if (orderBy?.date === "desc") {
           lines.sort((a, b) => b.date.getTime() - a.date.getTime());
+        }
+        if (typeof skip === "number" && skip > 0) {
+          lines = lines.slice(skip);
         }
         if (typeof take === "number") {
           lines = lines.slice(0, take);
@@ -180,8 +357,8 @@ function createPrismaStub(initial?: Partial<State>): Stub {
           orgId: data.orgId!,
           date: data.date as Date,
           amount: data.amount as any,
-          payee: data.payee!,
-          desc: data.desc!,
+          payee: data.payee ?? "",
+          desc: data.desc ?? "",
           createdAt: data.createdAt ?? new Date(),
         } as unknown as BankLine;
         state.bankLines.push(created);


### PR DESCRIPTION
## Summary
- add JWT/API key guard that scopes /users and /bank-lines data to the caller while redacting non-admin emails
- validate bank-line requests with Zod schemas and enforce 24h idempotency keyed responses
- expand privacy tests to cover auth requirements, scoping, redaction, and idempotency flows

## Testing
- pnpm -r build
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f64248c4048327ac52726d779d65eb