### PR TITLE
Add readiness, metrics, and graceful shutdown to API gateway

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -11,15 +11,55 @@ import { createApp } from "./app";
 
 const app = await createApp();
 
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
-
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
+try {
+  await app.listen({ port, host });
+} catch (err) {
+  app.log.error({ err }, "failed to start api-gateway");
   process.exit(1);
-});
+}
+
+const shutdownTimeoutMs = Number(process.env.SHUTDOWN_TIMEOUT ?? 10000);
+const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+let shuttingDown = false;
+
+for (const signal of signals) {
+  process.once(signal, () => {
+    void shutdown(signal);
+  });
+}
+
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
+  const startedAt = Date.now();
+  app.log.info({ signal }, "received shutdown signal");
+
+  let exitCode = 0;
+  const timeout = setTimeout(() => {
+    const duration = Date.now() - startedAt;
+    app.log.error({ duration }, "shutdown timed out");
+    exitCode = 1;
+    process.exit(exitCode);
+  }, shutdownTimeoutMs);
+  timeout.unref();
+
+  try {
+    await app.close();
+  } catch (err) {
+    exitCode = 1;
+    app.log.error({ err }, "failed to close app cleanly");
+  }
+
+  clearTimeout(timeout);
+  const duration = Date.now() - startedAt;
+  const log = exitCode === 0 ? app.log.info.bind(app.log) : app.log.error.bind(app.log);
+  log({ duration }, "shutdown complete");
+  process.exit(exitCode);
+}
 

--- a/services/api-gateway/test/privacy.spec.ts
+++ b/services/api-gateway/test/privacy.spec.ts
@@ -27,6 +27,8 @@ type PrismaLike = Pick<
   | "bankLine"
   | "orgTombstone"
   | "$transaction"
+  | "$disconnect"
+  | "$queryRaw"
 >;
 
 type Stub = {
@@ -208,6 +210,10 @@ function createPrismaStub(initial?: Partial<State>): Stub {
     $transaction: async <T>(callback: TransactionCallback<T>) => {
       return callback(client);
     },
+    $disconnect: async () => {
+      // no-op for tests
+    },
+    $queryRaw: async () => 1,
   } as unknown as PrismaLike;
 
   return { client, state };


### PR DESCRIPTION
## Summary
- add a /ready endpoint that probes Prisma before reporting readiness and expose /metrics with Prometheus-formatted counters
- record HTTP request counts per route/status and disconnect Prisma when Fastify closes
- add signal handlers to gracefully stop the API gateway with a timeout-based fallback

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f63bd9109083279b558b32216ccf88