### PR TITLE
Improve workflow alerts accessibility semantics

### DIFF
--- a/webapp/src/pages/Home.css
+++ b/webapp/src/pages/Home.css
@@ -92,14 +92,30 @@
 }
 
 .activity__item {
+  display: block;
+}
+
+.activity__card {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.activity__summary {
   display: flex;
   justify-content: space-between;
-  gap: var(--spacing-lg);
+  gap: var(--spacing-md);
   align-items: baseline;
 }
 
 .activity__name {
   font-size: var(--font-size-lg);
+}
+
+.activity__deadline {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
 }
 
 .activity__detail {
@@ -113,9 +129,25 @@
   font-weight: var(--font-weight-medium);
 }
 
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
 @media (max-width: 700px) {
-  .activity__item {
+  .activity__summary {
     flex-direction: column;
     align-items: flex-start;
+    gap: var(--spacing-3xs);
+  }
+
+  .activity__deadline {
+    white-space: normal;
   }
 }

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -26,16 +26,31 @@ const activities = [
   {
     name: 'GreenRidge solar expansion',
     detail: 'Closing diligence with Commonwealth Bank',
-    status: 'Due tomorrow'
+    deadline: {
+      display: 'Due tomorrow',
+      dateTime: '2024-06-21',
+      ariaLabel: 'GreenRidge solar expansion is due tomorrow'
+    },
+    status: 'Awaiting credit sign-off'
   },
   {
     name: 'Helios storage facility',
     detail: 'Amended terms shared with syndicate partners',
-    status: 'Updated 2h ago'
+    deadline: {
+      display: 'Updated 2h ago',
+      dateTime: '2024-06-20T14:00:00Z',
+      ariaLabel: 'Helios storage facility updated two hours ago'
+    },
+    status: 'Review revised syndicate comments'
   },
   {
     name: 'Urban mobility fund II',
     detail: 'Capital call scheduled for Monday',
+    deadline: {
+      display: 'Due Monday',
+      dateTime: '2024-06-24',
+      ariaLabel: 'Urban mobility fund II due on Monday'
+    },
     status: 'Action needed'
   }
 ];
@@ -70,15 +85,43 @@ export default function HomePage() {
           <p className="activity__subtitle">Curated tasks across deal teams and syndicate partners</p>
         </div>
         <ul className="activity__list">
-          {activities.map((activity) => (
-            <li className="activity__item" key={activity.name}>
-              <div>
-                <p className="activity__name">{activity.name}</p>
-                <p className="activity__detail">{activity.detail}</p>
-              </div>
-              <span className="activity__status">{activity.status}</span>
-            </li>
-          ))}
+          {activities.map((activity, index) => {
+            const titleId = `activity-name-${index}`;
+            const detailId = `activity-detail-${index}`;
+            const statusId = `activity-status-${index}`;
+
+            return (
+              <li className="activity__item" key={activity.name}>
+                <article
+                  className="activity__card"
+                  aria-labelledby={titleId}
+                  aria-describedby={`${detailId} ${statusId}`}
+                >
+                  <div className="activity__summary">
+                    <p className="activity__name" id={titleId}>
+                      {activity.name}
+                    </p>
+                    <time
+                      className="activity__deadline"
+                      dateTime={activity.deadline.dateTime}
+                      aria-label={activity.deadline.ariaLabel}
+                    >
+                      {activity.deadline.display}
+                    </time>
+                  </div>
+                  <p className="activity__detail" id={detailId}>
+                    {activity.detail}
+                  </p>
+                  <p className="activity__status" id={statusId}>
+                    <span aria-hidden="true">{activity.status}</span>
+                    <span className="visually-hidden">
+                      Status for {activity.name}: {activity.status}
+                    </span>
+                  </p>
+                </article>
+              </li>
+            );
+          })}
         </ul>
       </section>
     </div>

--- a/webapp/tests/axe.spec.ts
+++ b/webapp/tests/axe.spec.ts
@@ -15,5 +15,30 @@ for (const route of routes) {
 
       expect(results.violations).toEqual([]);
     });
+
+    if (route === '/') {
+      test('workflow alerts expose deadlines and statuses', async ({ page }) => {
+        await page.goto(route);
+        await page.waitForLoadState('networkidle');
+
+        const cards = page.locator('.activity__card');
+        const cardCount = await cards.count();
+        expect(cardCount).toBeGreaterThan(0);
+
+        for (let index = 0; index < cardCount; index += 1) {
+          const card = cards.nth(index);
+          await expect(card).toHaveAttribute('aria-labelledby', /activity-name-/);
+          await expect(card).toHaveAttribute('aria-describedby', /activity-detail-\d+ activity-status-\d+/);
+
+          const deadline = card.locator('time.activity__deadline');
+          await expect(deadline).toHaveCount(1);
+          await expect(deadline).toHaveAttribute('aria-label', /.+/);
+          await expect(deadline).toHaveAttribute('datetime', /.+/i);
+
+          const status = card.locator('.activity__status .visually-hidden');
+          await expect(status).toHaveCount(1);
+        }
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary
- wrap workflow alerts in labelled cards that pair task titles with machine-readable deadlines and hidden status announcements
- update the home page styles to accommodate the new task markup and add a visually hidden utility helper
- extend the axe smoke test to verify the workflow alert list exposes deadlines and statuses for assistive tech

## Testing
- pnpm dlx @playwright/test@1.48.0 test webapp/tests/axe.spec.ts *(fails: Process from config.webServer exited early)*
- pnpm install *(fails: No matching version found for required @opentelemetry packages in the workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e9c095d548327a83ac4e97f785838)