### PR TITLE
Improve Home metrics semantics and accessibility

### DIFF
--- a/webapp/src/pages/Home.css
+++ b/webapp/src/pages/Home.css
@@ -25,6 +25,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
   gap: var(--spacing-xl);
+  margin: 0;
 }
 
 .metric-card {
@@ -37,6 +38,11 @@
   box-shadow: var(--shadow-sm);
 }
 
+.metric-card dt,
+.metric-card dd {
+  margin: 0;
+}
+
 .metric-card__header {
   display: flex;
   justify-content: space-between;
@@ -45,7 +51,16 @@
   color: var(--color-text-muted);
 }
 
+.metric-card__title {
+  font-weight: var(--font-weight-medium);
+}
+
 .metric-card__change {
+  display: flex;
+  gap: var(--spacing-2xs);
+}
+
+.metric-card__change-badge {
   border-radius: var(--radius-pill);
   background-color: var(--color-primary-soft);
   color: var(--color-primary);
@@ -61,6 +76,18 @@
 .metric-card__description {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .activity {

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -51,17 +51,32 @@ export default function HomePage() {
         </p>
       </header>
 
-      <section aria-label="Key metrics" className="metric-grid">
-        {metrics.map((metric) => (
-          <article className="metric-card" key={metric.title}>
-            <header className="metric-card__header">
-              <h2>{metric.title}</h2>
-              <span className="metric-card__change">{metric.change}</span>
-            </header>
-            <p className="metric-card__value">{metric.value}</p>
-            <p className="metric-card__description">{metric.description}</p>
-          </article>
-        ))}
+      <section aria-label="Key metrics">
+        <dl className="metric-grid">
+          {metrics.map((metric, index) => {
+            const changeId = `metric-${index}-change`;
+
+            return (
+              <div className="metric-card" key={metric.title}>
+                <div className="metric-card__header">
+                  <dt className="metric-card__title">{metric.title}</dt>
+                  <dd className="metric-card__change">
+                    <span className="metric-card__change-badge" aria-hidden="true">
+                      {metric.change}
+                    </span>
+                    <span className="sr-only" id={changeId}>
+                      Change for {metric.title}: {metric.change}
+                    </span>
+                  </dd>
+                </div>
+                <dd aria-describedby={changeId} className="metric-card__value">
+                  {metric.value}
+                </dd>
+                <dd className="metric-card__description">{metric.description}</dd>
+              </div>
+            );
+          })}
+        </dl>
       </section>
 
       <section aria-label="Latest activity" className="activity">

--- a/webapp/tests/axe.spec.ts
+++ b/webapp/tests/axe.spec.ts
@@ -15,5 +15,22 @@ for (const route of routes) {
 
       expect(results.violations).toEqual([]);
     });
+
+    if (route === '/') {
+      test('should keep metrics section free of structural violations', async ({ page }) => {
+        await page.goto(route);
+        await page.waitForLoadState('networkidle');
+
+        const metricsSection = page.locator('section[aria-label="Key metrics"]');
+        await expect(metricsSection).toBeVisible();
+
+        const targetedResults = await new AxeBuilder({ page })
+          .withTags(['wcag2a', 'wcag2aa'])
+          .include('section[aria-label="Key metrics"]')
+          .analyze();
+
+        expect(targetedResults.violations).toEqual([]);
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary
- refactor the Home metrics cards to use description list semantics with accessible change descriptions
- update the Home page styles to preserve layout and badge appearance with the new markup
- expand the Playwright Axe test to include a focused check on the Home metrics section

## Testing
- pnpm exec playwright test webapp/tests/axe.spec.ts *(fails: Command "playwright" not found)*
- pnpm install *(fails: No matching version for @opentelemetry/instrumentation-fastify@^0.55.3)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e9c0709748327a638fdb3ba1007c2)