### PR TITLE
chore(deps): add Renovate + update policy + lockfile maintenance

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,60 @@
+name: Lockfile Maintenance
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lockfile:
+    name: Refresh pnpm lockfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Update lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Audit dependencies (high+)
+        run: pnpm audit --audit-level high
+
+      - name: Generate SBOM (CycloneDX)
+        run: pnpm dlx @cyclonedx/cyclonedx-npm --output-format json --output-file sbom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lockfile-sbom
+          path: sbom.json
+          if-no-files-found: error
+
+      - name: Create lockfile PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: chore(deps): refresh pnpm lockfile
+          branch: chore/lockfile-maintenance
+          delete-branch: true
+          title: 'chore(deps): refresh pnpm lockfile'
+          body: |
+            ## Summary
+            - ensure the pnpm lockfile stays in sync with workspace constraints
+            - require audit + SBOM generation for transparency before merging
+          labels: dependencies, automated-pr
+          add-paths: pnpm-lock.yaml
+          signoff: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "rangeStrategy": "replace",
+  "timezone": "UTC",
+  "schedule": ["after 10pm on sunday"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "postUpdateOptions": ["pnpmDedupe"],
+  "packageRules": [
+    {
+      "matchManagers": ["pnpm"],
+      "matchDepTypes": ["dependencies"],
+      "groupName": "workspace runtime dependencies",
+      "groupSlug": "workspace-runtime"
+    },
+    {
+      "matchManagers": ["pnpm"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "workspace dev dependencies",
+      "groupSlug": "workspace-dev",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "requiredStatusChecks": [
+        "CI / build",
+        "CI / axe",
+        "CI / lighthouse",
+        "Security Scans / security"
+      ]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a centralized Renovate configuration with scheduled update windows, grouped dependency cohorts, and CI/SCA-gated automerge for dev-only updates
- schedule weekly pnpm lockfile maintenance that audits dependencies, regenerates the SBOM, and opens a PR automatically when changes are detected

## Testing
- not run (config-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec745815483278dd08da509c68b90)