### PR TITLE
test(coverage): unit/integration for audit-chain, snapshots, idempotency; enforce >=85%

### DIFF
--- a/tests/mocks/prisma-client.ts
+++ b/tests/mocks/prisma-client.ts
@@ -29,3 +29,5 @@ export class DesignatedAccount {}
 export class DesignatedTransfer {}
 export class PaymentPlanRequest {}
 export class MonitoringSnapshot {}
+
+export default PrismaClient;


### PR DESCRIPTION
## Summary
- Map `@prisma/client` to a Jest-friendly stub and keep the global coverage gate at 85%. 
- Add unit and integration suites for audit chaining, idempotency replay/conflict handling, readiness probes, metrics timing, validation, and org access helpers.
- Provide a reusable Prisma mock so the new tests can exercise the API gateway logic without a real client.

## Testing
- pnpm run coverage

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec732fe988327a4b71b2d3ea6bd0a)