### PR TITLE
Scope prisma drift check to shared package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       # 5. Schema / merge hygiene gates
       - name: Check Prisma migration drift
-        run: pnpm -w exec prisma migrate status
+        run: pnpm --filter @apgms/shared exec prisma migrate status --schema prisma/schema.prisma
 
       - name: Conflict marker guard
         run: git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!*.lock'

--- a/scripts/check-prisma-drift.mjs
+++ b/scripts/check-prisma-drift.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const args = [
+  "--filter",
+  "@apgms/shared",
+  "exec",
+  "prisma",
+  "migrate",
+  "status",
+  "--schema",
+  "prisma/schema.prisma",
+];
+
+const child = spawn("pnpm", args, { stdio: "inherit" });
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    console.error(`check-prisma-drift terminated with signal ${signal}`);
+    process.exit(1);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+child.on("error", (error) => {
+  console.error("Failed to run pnpm for Prisma drift check:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- scope the CI Prisma migration drift check to the @apgms/shared workspace schema
- add a helper script that invokes pnpm with the shared schema for local reuse

## Testing
- ⚠️ `pnpm install --frozen-lockfile` *(fails: pnpm-lock.yaml is out of date with services/api-gateway/package.json)*
- ⚠️ `pnpm --filter @apgms/shared exec prisma migrate status --schema prisma/schema.prisma` *(fails without dependencies because install cannot complete due to the lockfile mismatch)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4fe339a4832799df373530a45d1a)