### PR TITLE
Ensure CI generates coverage before enforcing thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,15 @@ jobs:
         run: pnpm -r typecheck
 
       # 3. Tests + coverage gate
-      #    First run tests with coverage output...
-      - name: Test (with coverage)
-        run: pnpm -r test -- --coverage
+      #    Run all workspace tests (unit/integration) first...
+      - name: Tests
+        run: pnpm -r test
 
-      #    ...then enforce coverage budget (>=85% lines, etc.).
+      #    ...then generate a Jest coverage summary for enforcement.
+      - name: Generate coverage summary
+        run: pnpm coverage
+
+      #    Finally enforce coverage budget (>=85% lines, etc.).
       #    check-coverage.mjs should read the coverage summary JSON and exit 1 if below threshold.
       - name: Enforce coverage >=85%
         run: |

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const thresholds = {
+  lines: 85,
+  statements: 85,
+  functions: 85,
+  branches: 85,
+};
+
+const summaryPath = resolve(process.cwd(), "coverage", "coverage-summary.json");
+
+if (!existsSync(summaryPath)) {
+  console.error("\u274c coverage/coverage-summary.json not found.\n" +
+    "Run your test suite with coverage enabled (e.g. `pnpm coverage`) before enforcing coverage thresholds.");
+  process.exit(1);
+}
+
+let summaryRaw;
+try {
+  summaryRaw = await readFile(summaryPath, "utf8");
+} catch (error) {
+  console.error(`\u274c Failed to read coverage summary at ${summaryPath}`);
+  console.error(error);
+  process.exit(1);
+}
+
+let summary;
+try {
+  summary = JSON.parse(summaryRaw);
+} catch (error) {
+  console.error("\u274c coverage-summary.json is not valid JSON.");
+  console.error(error);
+  process.exit(1);
+}
+
+const total = summary.total;
+if (!total) {
+  console.error("\u274c coverage-summary.json is missing the expected 'total' field.");
+  process.exit(1);
+}
+
+const failures = [];
+for (const [metric, threshold] of Object.entries(thresholds)) {
+  const coverage = total[metric]?.pct;
+  if (typeof coverage !== "number") {
+    failures.push(`${metric}: missing`);
+    continue;
+  }
+  if (coverage < threshold) {
+    failures.push(`${metric}: ${coverage.toFixed(2)}% (required: ${threshold}%)`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("\u274c Coverage thresholds not met:");
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("\u2705 Coverage thresholds met:");
+for (const [metric, threshold] of Object.entries(thresholds)) {
+  const coverage = total[metric]?.pct ?? 0;
+  console.log(`  - ${metric}: ${coverage.toFixed(2)}% (required: ${threshold}%)`);
+}


### PR DESCRIPTION
## Summary
- run the full workspace test suite and then generate a Jest coverage report in CI before enforcing thresholds
- add a coverage gate script that validates each metric against the 85% requirement and reports missing coverage data clearly

## Testing
- pnpm coverage *(fails: jest is not installed because dependencies cannot be installed in this environment)*
- node ./scripts/check-coverage.mjs *(fails as expected when coverage output has not been generated)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4feed1dc83278e439e8e60f69c9d)