### PR TITLE
docs: align auth notes and control status with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ SHADOW_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/apgms_shadow?s
 AUTH_AUDIENCE=urn:apgms:local
 AUTH_ISSUER=urn:apgms:issuer
 AUTH_DEV_SECRET=local-dev-shared-secret-change-me # HS256 signing key shared by gateway + tests
+# TODO: remove once gateway stops requiring ensureJwksConfigured
+AUTH_JWKS={"keys":[]} # required placeholder until JWKS validation is retired
 ENCRYPTION_MASTER_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 API_RATE_LIMIT_MAX=120
 API_RATE_LIMIT_WINDOW=1 minute


### PR DESCRIPTION
## Summary
- update auth documentation to describe the HS256 shared secret rather than RS256/JWKS
- refresh ASVS and DPIA references and clarify the compliance control matrix, including the /security/users telemetry gap

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4ff0b42c8327a62c13fa2dfbb2e3)