### PR TITLE
chore(ledger): use cross-platform test script

### DIFF
--- a/packages/ledger/README.md
+++ b/packages/ledger/README.md
@@ -1,0 +1,11 @@
+# @apgms/ledger
+
+## Tests
+
+Run the unit tests with coverage via the package script:
+
+```bash
+pnpm --filter @apgms/ledger test
+```
+
+This delegates to `pnpm exec jest --config ../../jest.config.js --runTestsByPath ../../packages/ledger/tests/journalWriter.test.ts --coverage` to ensure the package-specific suite runs consistently across platforms.

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts",
-    "test": "..\\..\\node_modules\\.bin\\jest.cmd --config ../../jest.config.js --runTestsByPath ../../packages/ledger/tests/journalWriter.test.ts --coverage"
+    "test": "pnpm exec jest --config ../../jest.config.js --runTestsByPath ../../packages/ledger/tests/journalWriter.test.ts --coverage"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",


### PR DESCRIPTION
## Summary
- replace the Windows-only jest invocation in the ledger package with a pnpm exec command that works across platforms
- document the ledger package test workflow and point to the new pnpm exec jest command

## Testing
- pnpm --filter @apgms/ledger test *(fails: missing local ts-jest/@types/jest dependencies in workspace node_modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4fe969e483278547fb9c957491de)