### PR TITLE
Secure regulator login with server-side mapping

### DIFF
--- a/services/api-gateway/test/config.spec.ts
+++ b/services/api-gateway/test/config.spec.ts
@@ -21,6 +21,8 @@ const REQUIRED_KEYS = [
   "CORS_ALLOWED_ORIGINS",
   "ENCRYPTION_MASTER_KEY",
   "REGULATOR_ACCESS_CODE",
+  "REGULATOR_ORG_ID",
+  "REGULATOR_ACCESS_CODES",
   "REGULATOR_JWT_AUDIENCE",
   "REGULATOR_SESSION_TTL_MINUTES",
   "REQUIRE_TLS",
@@ -76,6 +78,11 @@ test("loadConfig parses typed values and defaults", () => {
   process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com, https://admin.example.com";
   process.env.ENCRYPTION_MASTER_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   process.env.REGULATOR_ACCESS_CODE = "code-123";
+  process.env.REGULATOR_ORG_ID = "org-primary";
+  process.env.REGULATOR_ACCESS_CODES = JSON.stringify({
+    "code-123": "org-primary",
+    "code-override": "org-secondary",
+  });
   process.env.REGULATOR_JWT_AUDIENCE = "urn:test:reg";
   process.env.REGULATOR_SESSION_TTL_MINUTES = "90";
   process.env.REQUIRE_TLS = "true";
@@ -99,6 +106,11 @@ test("loadConfig parses typed values and defaults", () => {
   assert.equal(config.encryption.masterKey.length, 32);
   assert.equal(config.auth.devSecret, "local-dev-secret");
   assert.equal(config.regulator.accessCode, "code-123");
+  assert.equal(config.regulator.orgId, "org-primary");
+  assert.deepEqual(config.regulator.accessCodeOrgMap, {
+    "code-123": "org-primary",
+    "code-override": "org-secondary",
+  });
   assert.equal(config.regulator.jwtAudience, "urn:test:reg");
   assert.equal(config.regulator.sessionTtlMinutes, 90);
   assert.equal(config.webauthn.rpId, "localhost");

--- a/services/api-gateway/test/regulator.auth.spec.ts
+++ b/services/api-gateway/test/regulator.auth.spec.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+
+import Fastify, { type FastifyInstance } from "fastify";
+
+import { config } from "../src/config";
+import { prisma } from "../src/db";
+import * as regulatorSession from "../src/lib/regulator-session";
+import * as audit from "../src/lib/audit";
+import { registerRegulatorAuthRoutes } from "../src/routes/regulator-auth";
+
+describe("POST /regulator/login", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify();
+    await registerRegulatorAuthRoutes(app);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    mock.restoreAll();
+  });
+
+  it("issues a token for a valid access code", async () => {
+    const expectedOrgId = config.regulator.accessCodeOrgMap[config.regulator.accessCode];
+    const issuedAt = new Date("2024-01-01T00:00:00.000Z");
+    const expiresAt = new Date("2024-01-01T01:00:00.000Z");
+
+    const findUniqueMock = mock.method(prisma.org, "findUnique", async (args: any) => {
+      assert.equal(args?.where?.id, expectedOrgId);
+      return { id: expectedOrgId };
+    });
+
+    const createSessionMock = mock.method(
+      regulatorSession,
+      "createRegulatorSession",
+      async (orgId: string, ttlMinutes: number) => {
+        assert.equal(orgId, expectedOrgId);
+        assert.equal(ttlMinutes, config.regulator.sessionTtlMinutes);
+        return {
+          session: { id: "session-123", issuedAt, expiresAt },
+          sessionToken: "session-token",
+        };
+      },
+    );
+
+    const auditMock = mock.method(audit, "recordAuditLog", async (entry: any) => {
+      assert.equal(entry.orgId, expectedOrgId);
+      assert.equal(entry.action, "regulator.login");
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/regulator/login",
+      payload: { accessCode: ` ${config.regulator.accessCode} ` },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      token: string;
+      orgId: string;
+      session: { id: string; issuedAt: string; expiresAt: string; sessionToken: string };
+    };
+
+    assert.equal(body.orgId, expectedOrgId);
+    assert.equal(body.session.id, "session-123");
+    assert.equal(body.session.issuedAt, issuedAt.toISOString());
+    assert.equal(body.session.expiresAt, expiresAt.toISOString());
+    assert.equal(body.session.sessionToken, "session-token");
+    assert.equal(typeof body.token, "string");
+    assert.ok(body.token.length > 0);
+
+    assert.equal(findUniqueMock.mock.calls.length, 1);
+    assert.equal(createSessionMock.mock.calls.length, 1);
+    assert.equal(auditMock.mock.calls.length, 1);
+  });
+
+  it("rejects unknown access codes", async () => {
+    const findUniqueMock = mock.method(prisma.org, "findUnique", async () => {
+      throw new Error("should not query database for invalid access codes");
+    });
+    const createSessionMock = mock.method(
+      regulatorSession,
+      "createRegulatorSession",
+      async () => {
+        throw new Error("should not create sessions for invalid access codes");
+      },
+    );
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/regulator/login",
+      payload: { accessCode: "nope" },
+    });
+
+    assert.equal(response.statusCode, 401);
+    const body = response.json() as { error: { code: string } };
+    assert.equal(body.error.code, "access_denied");
+    assert.equal(findUniqueMock.mock.calls.length, 0);
+    assert.equal(createSessionMock.mock.calls.length, 0);
+  });
+
+  it("rejects payloads with unexpected properties", async () => {
+    const findUniqueMock = mock.method(prisma.org, "findUnique", async () => {
+      throw new Error("should not query database for invalid payloads");
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/regulator/login",
+      payload: { accessCode: config.regulator.accessCode, orgId: "evil" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    const body = response.json() as { error: { code: string } };
+    assert.equal(body.error.code, "invalid_body");
+    assert.equal(findUniqueMock.mock.calls.length, 0);
+  });
+});

--- a/services/api-gateway/test/run.ts
+++ b/services/api-gateway/test/run.ts
@@ -19,6 +19,7 @@ const defaultTestEnv: Record<string, string> = {
   TAX_ENGINE_URL: "http://tax-engine:8000",
   CORS_ALLOWED_ORIGINS: "http://localhost:5173",
   REGULATOR_ACCESS_CODE: "regulator-dev-code",
+  REGULATOR_ORG_ID: "dev-org",
   REGULATOR_JWT_AUDIENCE: "urn:apgms:regulator",
   REGULATOR_SESSION_TTL_MINUTES: "60",
   ENCRYPTION_MASTER_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",

--- a/webapp/src/RegulatorLoginPage.tsx
+++ b/webapp/src/RegulatorLoginPage.tsx
@@ -6,7 +6,6 @@ import { saveRegulatorSession } from "./regulatorAuth";
 export default function RegulatorLoginPage() {
   const navigate = useNavigate();
   const [accessCode, setAccessCode] = useState("");
-  const [orgId, setOrgId] = useState("dev-org");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -15,7 +14,7 @@ export default function RegulatorLoginPage() {
     setError(null);
     setIsSubmitting(true);
     try {
-      const result = await regulatorLogin(accessCode, orgId);
+      const result = await regulatorLogin(accessCode);
       saveRegulatorSession({
         token: result.token,
         orgId: result.orgId,
@@ -50,18 +49,6 @@ export default function RegulatorLoginPage() {
               autoComplete="one-time-code"
               required
             />
-          </label>
-          <label style={labelStyle}>
-            <span>Organisation ID</span>
-            <input
-              value={orgId}
-              onChange={(event) => setOrgId(event.target.value)}
-              placeholder="dev-org"
-              style={inputStyle}
-            />
-            <span style={helperTextStyle}>
-              Default is <code>dev-org</code>; override to inspect another tenant.
-            </span>
           </label>
           {error ? (
             <div style={errorStyle}>
@@ -141,11 +128,6 @@ const inputStyle: React.CSSProperties = {
   borderRadius: "8px",
   border: "1px solid #cbd5f5",
   fontSize: "14px",
-};
-
-const helperTextStyle: React.CSSProperties = {
-  fontSize: "12px",
-  color: "#64748b",
 };
 
 const errorStyle: React.CSSProperties = {

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -451,6 +451,7 @@ export async function fetchEvidenceArtifactDetail(token: string, artifactId: str
 
 export type RegulatorLoginResponse = {
   token: string;
+  orgId: string;
   session: {
     id: string;
     issuedAt: string;
@@ -459,15 +460,13 @@ export type RegulatorLoginResponse = {
   };
 };
 
-export async function regulatorLogin(accessCode: string, orgId?: string) {
+export async function regulatorLogin(accessCode: string) {
   const trimmedCode = accessCode.trim();
-  const resolvedOrgId = orgId?.trim() && orgId.trim().length > 0 ? orgId.trim() : undefined;
   const res = await fetch(`${API_BASE}/regulator/login`, {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify({
       accessCode: trimmedCode,
-      orgId: resolvedOrgId,
     }),
   });
 
@@ -481,10 +480,7 @@ export async function regulatorLogin(accessCode: string, orgId?: string) {
   }
 
   const payload = (await res.json()) as RegulatorLoginResponse;
-  return {
-    ...payload,
-    orgId: resolvedOrgId ?? "dev-org",
-  };
+  return payload;
 }
 
 export async function fetchRegulatorComplianceReport(token: string) {


### PR DESCRIPTION
## Summary
- validate regulator login requests with a strict Zod schema and map access codes to server-defined org IDs before session issuance
- return the mapped org ID in the login response, update the regulator smoke script and portal to rely on server-side mapping, and disallow client-provided org IDs
- expand configuration support for multiple regulator codes and add integration tests covering successful login and rejection paths

## Testing
- pnpm --filter @apgms/api-gateway test *(fails: tsx executable unavailable until dependencies install; pnpm install is blocked by missing @opentelemetry/exporter-trace-otlp-http@^0.55.3)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4fe89690832780ad7c6345ded05f)