### PR TITLE
Add GST-free model training and evaluation scripts

### DIFF
--- a/apgms-ml/gstfree/train.py
+++ b/apgms-ml/gstfree/train.py
@@ -227,7 +227,7 @@ def train_model(data_path: Path, out_path: Path, metrics_path: Path) -> None:
     val_scores = model.predict_proba(X_val)[:, 1]
     test_scores = model.predict_proba(X_test)[:, 1]
 
-    selected = _select_threshold(y_test.to_numpy(), test_scores)
+    selected = _select_threshold(y_val.to_numpy(), val_scores)
     threshold = float(selected["threshold"])
 
     roc_auc = float(roc_auc_score(y_test, test_scores))
@@ -243,6 +243,7 @@ def train_model(data_path: Path, out_path: Path, metrics_path: Path) -> None:
 
     metrics_payload = {
         "threshold": threshold,
+        "validation_selected": selected,
         "validation": val_metrics_by_threshold,
         "test": {
             "roc_auc": roc_auc,


### PR DESCRIPTION
## Summary
- add a GST-free training CLI that builds the specified TF-IDF + logistic regression pipeline and writes metrics.json
- implement selection of a compliant decision threshold with bootstrap confidence intervals
- provide an evaluation CLI to reload the model, recompute metrics, and enforce ROC/FP/FN gates

## Testing
- python -m compileall apgms-ml/gstfree

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb7041b608327949e23cc28709732)