### PR TITLE
Add analytics common utilities

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,8 @@
+"""Common utilities for analytics workflows."""
+
+__all__ = [
+    "io",
+    "metrics",
+    "explain",
+    "thresholds",
+]

--- a/common/explain.py
+++ b/common/explain.py
@@ -1,0 +1,69 @@
+"""Model explanation helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+
+def top_tfidf_ngrams(vectorizer, clf, n: int = 25) -> List[Tuple[str, float]]:
+    """Return the most informative n-grams from a linear model.
+
+    Parameters
+    ----------
+    vectorizer:
+        A fitted text vectorizer that exposes ``get_feature_names_out``.
+    clf:
+        A linear classifier with a ``coef_`` attribute (e.g. LogisticRegression).
+    n:
+        Number of features to return.
+    """
+
+    if n <= 0:
+        return []
+
+    if not hasattr(vectorizer, "get_feature_names_out"):
+        raise AttributeError("vectorizer must implement get_feature_names_out")
+    if not hasattr(clf, "coef_"):
+        raise AttributeError("classifier must expose coef_ attribute")
+
+    feature_names = vectorizer.get_feature_names_out()
+    coefs = getattr(clf, "coef_")
+
+    coefs = np.asarray(coefs)
+    if coefs.ndim == 2:
+        # For multi-class problems take the last class (positive class in binary).
+        if coefs.shape[0] == 1:
+            coefs = coefs[0]
+        else:
+            coefs = coefs[-1]
+    elif coefs.ndim != 1:
+        raise ValueError("Unexpected coefficient shape")
+
+    if feature_names.shape[0] != coefs.shape[-1]:
+        raise ValueError("Number of coefficients does not match feature names")
+
+    feature_pairs = list(zip(feature_names, coefs))
+    feature_pairs.sort(key=lambda item: abs(item[1]), reverse=True)
+    return feature_pairs[:n]
+
+
+def pair_feature_debug(row_dict: Dict[str, object]) -> str:
+    """Create a deterministic string representation of feature-value pairs."""
+
+    if not row_dict:
+        return "<empty>"
+
+    parts = []
+    for key in sorted(row_dict):
+        value = row_dict[key]
+        if isinstance(value, float):
+            formatted = f"{value:.6g}"
+        else:
+            formatted = repr(value)
+        parts.append(f"{key}={formatted}")
+    return ", ".join(parts)
+
+
+__all__ = ["top_tfidf_ngrams", "pair_feature_debug"]

--- a/common/io.py
+++ b/common/io.py
@@ -1,0 +1,209 @@
+"""Input/output utilities for analytics workflows."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+def read_csv(path: str | os.PathLike[str]) -> pd.DataFrame:
+    """Read a CSV file into a dtype-aware :class:`pandas.DataFrame`.
+
+    The helper wraps :func:`pandas.read_csv` and applies
+    :meth:`DataFrame.convert_dtypes` to use nullable dtypes when possible.
+    This avoids unintended downcasts (e.g. of integers with missing values)
+    while remaining broadly compatible with downstream tooling.
+    """
+
+    df = pd.read_csv(path)
+    # ``convert_dtypes`` keeps nullable types (Int64, boolean, string, etc.)
+    # and attempts to infer better datatypes without losing information.
+    return df.convert_dtypes()
+
+
+def train_val_test_split(
+    df: pd.DataFrame,
+    time_col: Optional[str] = None,
+    ratios: Sequence[float] = (0.7, 0.15, 0.15),
+    stratify: Optional[Iterable] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Split a DataFrame into train/validation/test partitions.
+
+    Parameters
+    ----------
+    df:
+        The input dataframe to split.
+    time_col:
+        When provided, the dataframe is sorted by this column and split
+        sequentially using the desired ratios. This is useful for
+        time-series problems where shuffling is undesirable.
+    ratios:
+        Tuple of ``(train_ratio, val_ratio, test_ratio)``. The ratios are
+        normalised if they do not sum to one to provide a forgiving API.
+    stratify:
+        Optional iterable used for stratification when ``time_col`` is not
+        provided. The length must match ``df``.
+    """
+
+    if len(ratios) != 3:
+        raise ValueError("ratios must be a sequence of three floats")
+
+    total = float(sum(ratios))
+    if total <= 0:
+        raise ValueError("ratios must sum to a positive value")
+
+    ratios = tuple(r / total for r in ratios)
+
+    if time_col:
+        if time_col not in df.columns:
+            raise KeyError(f"time column '{time_col}' not in dataframe")
+
+        df_sorted = df.sort_values(time_col, kind="stable").reset_index(drop=True)
+        n = len(df_sorted)
+        train_end = math.floor(n * ratios[0])
+        val_end = math.floor(n * (ratios[0] + ratios[1]))
+
+        # Ensure that every row is assigned by pushing remainder to the test set.
+        train_df = df_sorted.iloc[:train_end].copy()
+        val_df = df_sorted.iloc[train_end:val_end].copy()
+        test_df = df_sorted.iloc[val_end:].copy()
+        return train_df, val_df, test_df
+
+    # Randomised split (with optional stratification).
+    if stratify is not None and len(df) != len(stratify):
+        raise ValueError("stratify iterable must be the same length as df")
+
+    train_ratio, val_ratio, test_ratio = ratios
+    temp_ratio = val_ratio + test_ratio
+    if temp_ratio == 0:
+        raise ValueError("validation and test ratios cannot both be zero")
+
+    df_train, df_temp = train_test_split(
+        df,
+        test_size=temp_ratio,
+        stratify=stratify,
+        random_state=42,
+        shuffle=True,
+    )
+
+    stratify_temp = None
+    if stratify is not None:
+        stratify_series = pd.Series(stratify, index=df.index)
+        stratify_temp = stratify_series.loc[df_temp.index]
+
+    if np.isclose(val_ratio, 0.0):
+        df_val = df_temp.iloc[0:0].copy()
+        df_test = df_temp.copy()
+    elif np.isclose(test_ratio, 0.0):
+        df_val = df_temp.copy()
+        df_test = df_temp.iloc[0:0].copy()
+    else:
+        test_fraction = test_ratio / temp_ratio
+        df_val, df_test = train_test_split(
+            df_temp,
+            test_size=test_fraction,
+            stratify=stratify_temp.values if stratify_temp is not None else None,
+            random_state=42,
+            shuffle=True,
+        )
+
+    return df_train.copy(), df_val.copy(), df_test.copy()
+
+
+def save_artifact(
+    model,
+    out_path: str | os.PathLike[str],
+    meta_dict: Optional[dict] = None,
+) -> Path:
+    """Persist an object alongside a manifest file.
+
+    Parameters
+    ----------
+    model:
+        The Python object to serialise with :mod:`joblib`.
+    out_path:
+        Destination path for the serialized artifact.
+    meta_dict:
+        Optional metadata to include in the manifest file.
+
+    Returns
+    -------
+    :class:`pathlib.Path`
+        Path to the saved artifact.
+    """
+
+    destination = Path(out_path)
+    ensure_dir(destination.parent)
+
+    joblib.dump(model, destination)
+
+    sha256 = _file_sha256(destination)
+    manifest = {
+        "artifact": destination.name,
+        "sha256": sha256,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "meta": meta_dict or {},
+    }
+
+    manifest_path = destination.with_name(f"{destination.stem}.manifest.json")
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return destination
+
+
+def _file_sha256(path: Path) -> str:
+    import hashlib
+
+    hasher = hashlib.sha256()
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def load_text_vectorizer(kind: str = "tfidf", **kwargs) -> TfidfVectorizer:
+    """Return a configured text vectorizer.
+
+    Currently only TF-IDF vectorizers are supported, but the helper keeps the
+    interface extensible for future additions.
+    """
+
+    kind = (kind or "").lower()
+    if kind != "tfidf":
+        raise ValueError(f"Unsupported vectorizer kind: {kind}")
+
+    defaults = {
+        "strip_accents": "unicode",
+        "lowercase": True,
+        "ngram_range": (1, 2),
+        "min_df": 2,
+    }
+    defaults.update(kwargs)
+
+    return TfidfVectorizer(**defaults)
+
+
+def ensure_dir(path: Optional[str | os.PathLike[str]]) -> Path:
+    """Ensure a directory exists and return it as a :class:`Path`."""
+
+    directory = Path(path) if path is not None else Path.cwd()
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+__all__ = [
+    "read_csv",
+    "train_val_test_split",
+    "save_artifact",
+    "load_text_vectorizer",
+    "ensure_dir",
+]

--- a/common/metrics.py
+++ b/common/metrics.py
@@ -1,0 +1,164 @@
+"""Evaluation utilities for binary classification models."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn import metrics
+
+
+def bin_class_metrics(
+    y_true: Iterable[int],
+    y_prob: Iterable[float],
+    threshold: float = 0.5,
+) -> Dict[str, float]:
+    """Compute common binary classification metrics.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ROC and PR AUCs, precision, recall, F1, accuracy,
+        support counts, and the confusion matrix entries (tn, fp, fn, tp).
+    """
+
+    y_true_arr = np.asarray(y_true)
+    y_prob_arr = np.asarray(y_prob)
+
+    if y_true_arr.shape[0] != y_prob_arr.shape[0]:
+        raise ValueError("y_true and y_prob must be the same length")
+
+    if not (0.0 <= threshold <= 1.0):
+        raise ValueError("threshold must be within [0, 1]")
+
+    y_pred = (y_prob_arr >= threshold).astype(int)
+
+    auc_roc = metrics.roc_auc_score(y_true_arr, y_prob_arr)
+    auc_pr = metrics.average_precision_score(y_true_arr, y_prob_arr)
+
+    tn, fp, fn, tp = metrics.confusion_matrix(y_true_arr, y_pred, labels=[0, 1]).ravel()
+
+    precision = metrics.precision_score(y_true_arr, y_pred, zero_division=0)
+    recall = metrics.recall_score(y_true_arr, y_pred, zero_division=0)
+    f1 = metrics.f1_score(y_true_arr, y_pred, zero_division=0)
+    accuracy = metrics.accuracy_score(y_true_arr, y_pred)
+
+    result = {
+        "auc_roc": float(auc_roc),
+        "auc_pr": float(auc_pr),
+        "precision": float(precision),
+        "recall": float(recall),
+        "f1": float(f1),
+        "accuracy": float(accuracy),
+        "tn": int(tn),
+        "fp": int(fp),
+        "fn": int(fn),
+        "tp": int(tp),
+        "support0": int(tn + fp),
+        "support1": int(fn + tp),
+    }
+
+    return result
+
+
+def bootstrap_ci(
+    fn: Callable[[np.ndarray], float] | Callable[[], float],
+    n_boot: int = 200,
+    seed: int = 1337,
+) -> Mapping[str, float]:
+    """Bootstrap confidence interval for a metric function.
+
+    Parameters
+    ----------
+    fn:
+        Metric function. If the callable accepts one positional argument it is
+        assumed to be an array of bootstrap indices. The callable may close
+        over the original data arrays. When the callable accepts no arguments
+        it is executed directly each iteration (assumed to perform its own
+        sampling).
+    n_boot:
+        Number of bootstrap iterations.
+    seed:
+        Random seed for reproducibility.
+    """
+
+    if n_boot <= 0:
+        raise ValueError("n_boot must be a positive integer")
+
+    rng = np.random.default_rng(seed)
+
+    import inspect
+
+    signature = inspect.signature(fn)
+    expects_arg = len(signature.parameters) > 0
+
+    sample_size: Optional[int] = getattr(fn, "n_samples", None)
+
+    if expects_arg and sample_size is None:
+        closure = getattr(fn, "__closure__", None)
+        if closure:
+            lengths = []
+            for cell in closure:
+                obj = cell.cell_contents
+                try:
+                    lengths.append(len(obj))
+                except TypeError:
+                    continue
+            if lengths:
+                # Choose the most common length among closure variables.
+                values, counts = np.unique(lengths, return_counts=True)
+                sample_size = int(values[np.argmax(counts)])
+
+    if expects_arg and sample_size is None:
+        raise ValueError(
+            "Unable to infer sample size for bootstrap; set `fn.n_samples` manually."
+        )
+
+    samples = []
+    for _ in range(n_boot):
+        if expects_arg:
+            assert sample_size is not None  # for type checkers
+            indices = rng.integers(0, sample_size, size=sample_size)
+            value = fn(indices)
+        else:
+            value = fn()
+        samples.append(float(value))
+
+    mean = float(np.mean(samples))
+    low, high = np.percentile(samples, [2.5, 97.5])
+
+    return {"mean": mean, "low": float(low), "high": float(high)}
+
+
+def calibration_curve_data(
+    y_true: Iterable[int],
+    y_prob: Iterable[float],
+    n_bins: int = 10,
+) -> pd.DataFrame:
+    """Generate calibration curve summary data."""
+
+    if n_bins <= 0:
+        raise ValueError("n_bins must be positive")
+
+    df = pd.DataFrame({"y_true": y_true, "y_prob": y_prob})
+    if df.empty:
+        return pd.DataFrame(columns=["bin_lower", "bin_upper", "prob_pred", "prob_true", "count"])
+
+    bins = np.linspace(0.0, 1.0, n_bins + 1)
+    df["bin"] = pd.cut(df["y_prob"], bins=bins, include_lowest=True)
+
+    agg = (
+        df.groupby("bin", observed=True)
+        .agg(prob_pred=("y_prob", "mean"), prob_true=("y_true", "mean"), count=("y_true", "size"))
+        .reset_index()
+    )
+
+    agg["bin_lower"] = agg["bin"].apply(lambda interval: interval.left if hasattr(interval, "left") else np.nan)
+    agg["bin_upper"] = agg["bin"].apply(lambda interval: interval.right if hasattr(interval, "right") else np.nan)
+    agg = agg.sort_values("bin_lower").reset_index(drop=True)
+
+    return agg[["bin_lower", "bin_upper", "prob_pred", "prob_true", "count"]]
+
+
+__all__ = ["bin_class_metrics", "bootstrap_ci", "calibration_curve_data"]

--- a/common/thresholds.py
+++ b/common/thresholds.py
@@ -1,0 +1,84 @@
+"""Threshold selection helpers for binary classifiers."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import numpy as np
+from sklearn import metrics
+
+
+VALID_OBJECTIVES = {
+    "f1": metrics.f1_score,
+    "precision": metrics.precision_score,
+    "recall": metrics.recall_score,
+    "accuracy": metrics.accuracy_score,
+    "balanced_accuracy": metrics.balanced_accuracy_score,
+}
+
+
+def choose_threshold_for_costs(
+    y_true: Iterable[int],
+    y_prob: Iterable[float],
+    max_fp_rate: Optional[float] = None,
+    max_fn_rate: Optional[float] = None,
+    maximize: str = "f1",
+) -> float:
+    """Select the best probability threshold subject to cost constraints."""
+
+    y_true_arr = np.asarray(y_true)
+    y_prob_arr = np.asarray(y_prob)
+
+    if y_true_arr.shape[0] != y_prob_arr.shape[0]:
+        raise ValueError("y_true and y_prob must be the same length")
+
+    if maximize not in VALID_OBJECTIVES:
+        raise ValueError(f"Unsupported objective '{maximize}'")
+
+    negatives = np.sum(y_true_arr == 0)
+    positives = np.sum(y_true_arr == 1)
+
+    thresholds = np.unique(np.concatenate(([0.0, 1.0], y_prob_arr)))
+    thresholds.sort()
+
+    best_threshold = 0.5
+    best_score = -np.inf
+    objective_fn = VALID_OBJECTIVES[maximize]
+
+    for threshold in thresholds:
+        y_pred = predict_with_threshold(y_prob_arr, threshold)
+        tn, fp, fn, tp = metrics.confusion_matrix(y_true_arr, y_pred, labels=[0, 1]).ravel()
+
+        fp_rate = fp / negatives if negatives else 0.0
+        fn_rate = fn / positives if positives else 0.0
+
+        if max_fp_rate is not None and fp_rate > max_fp_rate:
+            continue
+        if max_fn_rate is not None and fn_rate > max_fn_rate:
+            continue
+
+        if maximize in {"precision", "recall", "f1"}:
+            score = objective_fn(y_true_arr, y_pred, zero_division=0)
+        else:
+            score = objective_fn(y_true_arr, y_pred)
+        if score > best_score or (np.isclose(score, best_score) and threshold < best_threshold):
+            best_score = score
+            best_threshold = float(threshold)
+
+    if best_score == -np.inf:
+        raise ValueError("No threshold satisfies the provided constraints")
+
+    return best_threshold
+
+
+def predict_with_threshold(y_prob: Iterable[float], t: float) -> np.ndarray:
+    """Apply a probability threshold and return binary predictions."""
+
+    if not (0.0 <= t <= 1.0):
+        raise ValueError("threshold must be within [0, 1]")
+
+    y_prob_arr = np.asarray(y_prob)
+    return (y_prob_arr >= t).astype(int)
+
+
+__all__ = ["choose_threshold_for_costs", "predict_with_threshold"]


### PR DESCRIPTION
## Summary
- add IO helpers for reading CSVs, dataset splits, artifact manifests, and text vectorizers
- implement binary classification metrics, bootstrapping utilities, and calibration curve data prep
- provide explanation helpers and cost-aware threshold selection utilities

## Testing
- python -m compileall common

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb6fc4c0083278d0ea101ca83ea33)