### PR TITLE
Add LightGBM training entrypoint for PAYGW variance model

### DIFF
--- a/apgms_ml/paygw_var/train.py
+++ b/apgms_ml/paygw_var/train.py
@@ -165,8 +165,13 @@ def _compute_metrics(
                 "f1": float(value.get("f1-score", 0.0)),
                 "support": int(value.get("support", 0)),
             }
-        else:
+        elif isinstance(value, dict):
             metrics[key] = {k: float(v) for k, v in value.items() if isinstance(v, (int, float))}
+        elif isinstance(value, (int, float)):
+            metrics[key] = {"value": float(value)}
+        else:
+            # Fallback for unexpected shapes such as nested labels or None entries.
+            metrics[key] = {}
 
     metrics["micro avg"] = {
         "precision": float(precision_micro),


### PR DESCRIPTION
## Summary
- implement a LightGBM-based classifier for PAYGW variance label_status predictions
- persist the trained model, metrics, and gate results while enforcing precision/recall targets
- expose package modules to allow invocation via python -m apgms_ml.paygw_var.train

## Testing
- python -m compileall apgms_ml/paygw_var/train.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb7134af083279ed888da173771f8)