### PR TITLE
Add synthetic APGMS ML scaffolding

### DIFF
--- a/apgms-ml/common/io.py
+++ b/apgms-ml/common/io.py
@@ -65,19 +65,7 @@ def dump_model_artifact(
     """Persist *payload* to *path* using joblib and return the SHA-256 hash."""
     ensure_directory(path.parent)
     joblib.dump(payload, path)
-    sha = compute_sha256(path)
-    payload = dict(payload)
-    metadata = dict(payload.get("metadata", {}))
-    metadata["sha256"] = sha
-    payload["metadata"] = metadata
-    joblib.dump(payload, path)
-    final_sha = compute_sha256(path)
-    if final_sha != sha:
-        metadata["sha256"] = final_sha
-        payload["metadata"] = metadata
-        joblib.dump(payload, path)
-        final_sha = compute_sha256(path)
-    return final_sha
+    return compute_sha256(path)
 
 
 def make_metadata(


### PR DESCRIPTION
## Summary
- add the `apgms-ml` package with shared IO, metrics, explainability, and threshold helpers for non-QA models
- scaffold training and evaluation scripts for GST-free, BAS confidence, PAYGW variance, duplicate detection, and apportionment models with deterministic synthetic datasets
- include PowerShell orchestration scripts, model artifact directories, placeholder READMEs, and pinned dependencies in a dedicated pyproject

## Testing
- python -m compileall apgms-ml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb6e854588327aed6001fb7060f22)