### PR TITLE
Add PowerShell automation scripts for ML training and operations

### DIFF
--- a/apgms-ml/scripts/Promote-Model.ps1
+++ b/apgms-ml/scripts/Promote-Model.ps1
@@ -1,0 +1,117 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("gstfree", "bas_conf", "paygw_var", "dups", "apportion")]
+    [string]$Surface,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ModelPath,
+
+    [double]$Threshold,
+
+    [string[]]$Bands
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $ModelPath)) {
+    throw "Model artifact '$ModelPath' was not found."
+}
+
+if (-not $PSBoundParameters.ContainsKey("Threshold") -and (-not $Bands -or $Bands.Count -eq 0)) {
+    throw "Specify -Threshold or -Bands to describe the promotion criteria."
+}
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+$productionRoot = Join-Path (Join-Path $repoRoot "model") "production"
+$liveRoot = Join-Path (Join-Path $repoRoot "model") "live"
+
+foreach ($path in @($productionRoot, $liveRoot)) {
+    if (-not (Test-Path $path)) {
+        New-Item -ItemType Directory -Path $path | Out-Null
+    }
+}
+
+$shortSha = "nogit"
+$fullSha = ""
+try {
+    $shortShaResult = (& git rev-parse --short HEAD 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $shortShaResult) {
+        $shortSha = $shortShaResult.Trim()
+    }
+}
+catch {
+    # ignore
+}
+
+try {
+    $fullShaResult = (& git rev-parse HEAD 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $fullShaResult) {
+        $fullSha = $fullShaResult.Trim()
+    }
+}
+catch {
+    # ignore
+}
+
+$today = Get-Date -Format "yyyy-MM-dd"
+$versionedName = "model_{0}_{1}_{2}.joblib" -f $Surface, $today, $shortSha
+$versionedPath = Join-Path $productionRoot $versionedName
+
+Copy-Item -Path $ModelPath -Destination $versionedPath -Force
+
+$hash = (Get-FileHash -Path $versionedPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+$thresholdValue = if ($PSBoundParameters.ContainsKey("Threshold")) {
+    "{0:G}" -f $Threshold
+} elseif ($Bands) {
+    ($Bands | ForEach-Object { $_.ToString() }) -join "/"
+} else {
+    ""
+}
+
+$createdUtc = (Get-Date).ToUniversalTime().ToString("o")
+$manifestName = "manifest_{0}_{1}.txt" -f $Surface, (Get-Date -Format "yyyyMMdd_HHmmss")
+$manifestPath = Join-Path $productionRoot $manifestName
+
+$modelRelative = try {
+    [System.IO.Path]::GetRelativePath($repoRoot, (Resolve-Path $versionedPath).Path)
+} catch {
+    $versionedPath
+}
+
+$manifestContent = @(
+    "model_file=$modelRelative",
+    "sha256=$hash",
+    "threshold_or_bands=$thresholdValue",
+    "created_utc=$createdUtc"
+)
+if ($fullSha) {
+    $manifestContent += "repo_sha=$fullSha"
+}
+
+Set-Content -Path $manifestPath -Value $manifestContent
+
+$livePath = Join-Path $liveRoot ("$Surface.joblib")
+if (Test-Path $livePath) {
+    Remove-Item -Path $livePath -Force
+}
+
+try {
+    New-Item -ItemType HardLink -Path $livePath -Target $versionedPath | Out-Null
+}
+catch {
+    # fallback to copy if hardlink unsupported
+    Copy-Item -Path $versionedPath -Destination $livePath -Force
+}
+
+Write-Host "Promoted model stored at $versionedPath"
+Write-Host "Manifest: $manifestPath"
+if ($thresholdValue) {
+    Write-Host "Threshold/Bands: $thresholdValue"
+} else {
+    Write-Host "Threshold/Bands: (not specified)"
+}

--- a/apgms-ml/scripts/Shadow-Smoke.ps1
+++ b/apgms-ml/scripts/Shadow-Smoke.ps1
@@ -1,0 +1,155 @@
+[CmdletBinding(DefaultParameterSetName = "ByPeriod")]
+param(
+    [Parameter(ParameterSetName = "ByPeriod", Mandatory = $true)]
+    [string[]]$Period,
+
+    [Parameter(ParameterSetName = "ByFiles", Mandatory = $true)]
+    [hashtable]$Paths,
+
+    [string]$Python = "python"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$surfaces = @("gstfree", "bas_conf", "paygw_var", "dups", "apportion")
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+$dataRoot = Join-Path $repoRoot "data"
+$shadowRoot = Join-Path $dataRoot "shadow"
+$modelRoot = Join-Path (Join-Path $repoRoot "model") "live"
+$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+
+if (-not (Test-Path $modelRoot)) {
+    throw "Live model directory '$modelRoot' was not found."
+}
+
+function Get-InputFile {
+    param(
+        [string]$Surface
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq "ByFiles") {
+        if (-not $Paths.ContainsKey($Surface)) {
+            throw "Input paths missing entry for surface '$Surface'."
+        }
+        $resolved = Resolve-Path -Path $Paths[$Surface]
+        return $resolved.Path
+    }
+
+    $surfaceDir = Join-Path $shadowRoot $Surface
+    if (-not (Test-Path $surfaceDir)) {
+        throw "Shadow data directory '$surfaceDir' was not found."
+    }
+
+    $candidates = @()
+    foreach ($token in $Period) {
+        $pattern = "*$token*.csv"
+        $candidates += Get-ChildItem -Path $surfaceDir -Filter $pattern -File -ErrorAction SilentlyContinue
+    }
+
+    if (-not $candidates) {
+        throw "No CSV input found for surface '$Surface' using period filter '$($Period -join ",")'."
+    }
+
+    $selected = $candidates | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    return $selected.FullName
+}
+
+$summaryRows = @()
+
+foreach ($surface in $surfaces) {
+    $inputPath = Get-InputFile -Surface $surface
+    $modelPath = Join-Path $modelRoot ("$surface.joblib")
+    if (-not (Test-Path $modelPath)) {
+        throw "Live model for surface '$surface' was not found at '$modelPath'."
+    }
+
+    $scoreArgs = @($Python, "-m", "apgms_ml.shadow.score", "--surface", $surface, "--model", $modelPath, "--input", $inputPath, "--format", "json")
+    Write-Host "[Shadow] $surface" -ForegroundColor Cyan
+    Write-Host "  model: $modelPath" -ForegroundColor DarkGray
+    Write-Host "  input: $inputPath" -ForegroundColor DarkGray
+
+    $scoreOutput = & $scoreArgs[0] @($scoreArgs[1..($scoreArgs.Length - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw "Shadow scoring for '$surface' failed with exit code $LASTEXITCODE."
+    }
+
+    $score = $null
+    try {
+        $score = $scoreOutput | ConvertFrom-Json
+    }
+    catch {
+        throw "Failed to parse scoring output for '$surface' as JSON. Output:`n$scoreOutput"
+    }
+
+    if (-not $score) {
+        throw "Scoring for '$surface' produced no data."
+    }
+
+    $records = @()
+    if ($score.records) {
+        $records = @($score.records)
+    } elseif ($score.results) {
+        $records = @($score.results)
+    }
+
+    if (-not $records) {
+        throw "Scoring for '$surface' did not include any records."
+    }
+
+    $thresholdOrBands = if ($null -ne $score.threshold) {
+        if ($score.threshold -is [double]) { "{0:N3}" -f [double]$score.threshold } else { "$($score.threshold)" }
+    } elseif ($score.bands) {
+        if ($score.bands -is [System.Collections.IEnumerable] -and -not ($score.bands -is [string])) {
+            ($score.bands | ForEach-Object { "$_" }) -join "/"
+        } else {
+            "$($score.bands)"
+        }
+    } else {
+        ""
+    }
+
+    $outputFile = Join-Path $repoRoot ("shadow_{0}_{1}.csv" -f $surface, $timestamp)
+    $csvRows = foreach ($entry in $records) {
+        $inputData = if ($entry.input) { $entry.input } elseif ($entry.inputs) { $entry.inputs } else { $null }
+        $inputText = if ($null -ne $inputData) { ($inputData | ConvertTo-Json -Compress) } else { "" }
+        $probability = if ($null -ne $entry.probability) { [double]$entry.probability } elseif ($null -ne $entry.score) { [double]$entry.score } else { $null }
+        $bandValue = if ($entry.band) { "$($entry.band)" } elseif ($entry.segment) { "$($entry.segment)" } else { $null }
+        $decisionValue = if ($entry.decision) { "$($entry.decision)" } elseif ($entry.action) { "$($entry.action)" } else { "" }
+        $probOrBand = if ($null -ne $probability) { "{0:N4}" -f $probability } elseif ($bandValue) { $bandValue } else { "" }
+
+        [pscustomobject]@{
+            inputs     = $inputText
+            "prob/band" = $probOrBand
+            decision   = $decisionValue
+            threshold  = $thresholdOrBands
+        }
+    }
+
+    $csvRows | Export-Csv -Path $outputFile -NoTypeInformation -Encoding UTF8
+
+    $bucketCounts = @{}
+    foreach ($entry in $records) {
+        $bucket = if ($entry.band) { "$($entry.band)" } elseif ($entry.segment) { "$($entry.segment)" } elseif ($entry.decision) { "$($entry.decision)" } elseif ($entry.action) { "$($entry.action)" } else { "unknown" }
+        if (-not $bucketCounts.ContainsKey($bucket)) {
+            $bucketCounts[$bucket] = 0
+        }
+        $bucketCounts[$bucket] += 1
+    }
+
+    $summaryRows += [pscustomobject]@{
+        Surface = $surface
+        Output  = $outputFile
+        Buckets = ($bucketCounts.GetEnumerator() | Sort-Object Name | ForEach-Object { "{0}={1}" -f $_.Key, $_.Value }) -join ", "
+        Threshold = if ($thresholdOrBands) { $thresholdOrBands } else { "(n/a)" }
+    }
+}
+
+if ($summaryRows) {
+    Write-Host ""
+    foreach ($row in $summaryRows) {
+        Write-Host ("{0}: {1} | threshold/bands: {2}" -f $row.Surface, $row.Buckets, $row.Threshold)
+        Write-Host ("  output => {0}" -f $row.Output) -ForegroundColor DarkGray
+    }
+}

--- a/apgms-ml/scripts/Train-All.ps1
+++ b/apgms-ml/scripts/Train-All.ps1
@@ -1,0 +1,101 @@
+[CmdletBinding()]
+param(
+    [string]$Python = "python"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptRoot "..")).Path
+$dataRoot = Join-Path $repoRoot "data"
+$candidateRoot = Join-Path (Join-Path $repoRoot "model") "candidates"
+
+if (-not (Test-Path $dataRoot)) {
+    throw "Data directory '$dataRoot' was not found."
+}
+
+if (-not (Test-Path $candidateRoot)) {
+    New-Item -ItemType Directory -Path $candidateRoot | Out-Null
+}
+
+$trainDefinitions = @(
+    @{ Surface = "gstfree"; TrainerModule = "apgms_ml.trainers.gstfree.train"; EvaluatorModule = "apgms_ml.trainers.gstfree.evaluate" },
+    @{ Surface = "bas_conf"; TrainerModule = "apgms_ml.trainers.bas_conf.train"; EvaluatorModule = "apgms_ml.trainers.bas_conf.evaluate" },
+    @{ Surface = "paygw_var"; TrainerModule = "apgms_ml.trainers.paygw_var.train"; EvaluatorModule = "apgms_ml.trainers.paygw_var.evaluate" },
+    @{ Surface = "dups"; TrainerModule = "apgms_ml.trainers.dups.train"; EvaluatorModule = "apgms_ml.trainers.dups.evaluate" },
+    @{ Surface = "apportion"; TrainerModule = "apgms_ml.trainers.apportion.train"; EvaluatorModule = "apgms_ml.trainers.apportion.evaluate" }
+)
+
+$results = @()
+
+foreach ($definition in $trainDefinitions) {
+    $surface = $definition.Surface
+    $dataDir = Join-Path $dataRoot $surface
+    if (-not (Test-Path $dataDir)) {
+        throw "Expected data directory '$dataDir' for surface '$surface'."
+    }
+
+    $modelOutput = Join-Path $candidateRoot ("$surface.joblib")
+
+    $trainArgs = @($Python, "-m", $definition.TrainerModule, "--data-dir", $dataDir, "--output-model", $modelOutput)
+    Write-Host "[Train] $surface -> $modelOutput" -ForegroundColor Cyan
+    $trainOutput = & $trainArgs[0] @($trainArgs[1..($trainArgs.Length - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw "Training for '$surface' failed with exit code $LASTEXITCODE."
+    }
+    if ($trainOutput) {
+        $trainOutput | ForEach-Object { Write-Host "  $_" }
+    }
+
+    $evalArgs = @($Python, "-m", $definition.EvaluatorModule, "--data-dir", $dataDir, "--model", $modelOutput, "--format", "json")
+    Write-Host "[Eval] $surface" -ForegroundColor Yellow
+    $evalOutput = & $evalArgs[0] @($evalArgs[1..($evalArgs.Length - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw "Evaluation for '$surface' failed with exit code $LASTEXITCODE."
+    }
+
+    $metrics = $null
+    try {
+        $metrics = $evalOutput | ConvertFrom-Json
+    }
+    catch {
+        throw "Failed to parse evaluation output for '$surface' as JSON. Output:`n$evalOutput"
+    }
+
+    if (-not $metrics) {
+        throw "Evaluation for '$surface' returned no metrics."
+    }
+
+    $auc = if ($null -ne $metrics.auc) { [double]$metrics.auc } elseif ($metrics.metrics -and $null -ne $metrics.metrics.auc) { [double]$metrics.metrics.auc } else { $null }
+    $f1 = if ($null -ne $metrics.f1) { [double]$metrics.f1 } elseif ($metrics.metrics -and $null -ne $metrics.metrics.f1) { [double]$metrics.metrics.f1 } else { $null }
+    $threshold = if ($null -ne $metrics.threshold) { $metrics.threshold } elseif ($metrics.metrics -and $null -ne $metrics.metrics.threshold) { $metrics.metrics.threshold } else { $null }
+    $bands = if ($null -ne $metrics.bands) { $metrics.bands } elseif ($metrics.metrics -and $null -ne $metrics.metrics.bands) { $metrics.metrics.bands } else { $null }
+    $passed = if ($null -ne $metrics.passed) { [bool]$metrics.passed } elseif ($metrics.status -eq "pass") { $true } elseif ($metrics.status -eq "fail") { $false } else { $null }
+
+    $metricText = if ($null -ne $auc) { "AUC={0:N3}" -f $auc } elseif ($null -ne $f1) { "F1={0:N3}" -f $f1 } else { "-" }
+    $thresholdText = if ($null -ne $threshold) {
+        if ($threshold -is [double]) { "{0:N3}" -f [double]$threshold } else { "$threshold" }
+    } elseif ($bands) {
+        if ($bands -is [System.Collections.IEnumerable] -and -not ($bands -is [string])) {
+            ($bands | ForEach-Object { "$_" }) -join "/"
+        } else {
+            "$bands"
+        }
+    } else {
+        "-"
+    }
+    $statusText = if ($passed -eq $false) { "FAIL" } else { "PASS" }
+
+    $results += [pscustomobject]@{
+        Model = $surface
+        Metric = $metricText
+        Threshold = $thresholdText
+        Status = $statusText
+    }
+}
+
+if ($results.Count -gt 0) {
+    Write-Host ""
+    ($results | Format-Table -AutoSize | Out-String).TrimEnd() | Write-Host
+}


### PR DESCRIPTION
## Summary
- add Train-All orchestrator that runs each surface trainer with shared data paths and reports metrics
- add Shadow-Smoke helper to score recent extracts with live models and emit summaries and CSVs
- add Promote-Model workflow to version model artifacts, write manifests, and refresh live hardlinks

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb72bb7488327bd983962e8fe72e3)