### PR TITLE
feat: add payroll anomaly ML training workflow

### DIFF
--- a/ml/scripts/train_model.py
+++ b/ml/scripts/train_model.py
@@ -54,7 +54,7 @@ def _build_pipeline(
     model_params: Dict,
     unsupervised: bool,
 ) -> Pipeline:
-    categorical_transformer = OneHotEncoder(handle_unknown="ignore")
+    categorical_transformer = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
     numerical_transformer = Pipeline(steps=[("scaler", StandardScaler())])
 
     categorical_features = [col for col in feature_config.categorical_columns if col in feature_columns]


### PR DESCRIPTION
## Summary
- add a new `ml/` workspace with curated payroll dataset, feature engineering utilities, and CLI scripts for training and evaluation
- integrate MLflow infrastructure documentation plus example Helm values for storage and credentials configuration
- wire up a scheduled GitHub Actions workflow to retrain, evaluate, sign, and publish payroll anomaly detector artefacts

## Testing
- python -m ml.scripts.train_model --config ml/config/training.yaml
- python -m ml.scripts.evaluate_model --model ml/artifacts/model.joblib --dataset ml/data/curated_payroll_anomalies.csv --output ml/artifacts/evaluation.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb988f64c8327a63ea0ee09e6e66f)