### PR TITLE
Add analytics telemetry store and feature ETL

### DIFF
--- a/domain/ledger/journal-service.ts
+++ b/domain/ledger/journal-service.ts
@@ -20,28 +20,35 @@ export async function writeLedgerJournal(
   const result = await writer.write(input);
 
   if (context.analyticsLogger) {
-    await context.analyticsLogger({
-      orgId: input.orgId,
-      eventType: "journal.write",
-      occurredAt: input.occurredAt,
-      payload: {
-        eventId: input.eventId,
-        dedupeId: input.dedupeId,
-        type: input.type,
-        description: input.description ?? null,
-        source: input.source,
-        postings: input.postings.map((posting) => ({
-          accountId: posting.accountId,
-          amountCents: BigInt(posting.amountCents).toString(),
-          memo: posting.memo ?? null,
-        })),
-        analytics: input.analyticsPayload ?? null,
-      },
-      labels: {
-        created: result.created,
-        type: input.type,
-      },
-    });
+    try {
+      await context.analyticsLogger({
+        orgId: input.orgId,
+        eventType: "journal.write",
+        occurredAt: input.occurredAt,
+        payload: {
+          eventId: input.eventId,
+          dedupeId: input.dedupeId,
+          type: input.type,
+          description: input.description ?? null,
+          source: input.source,
+          postings: input.postings.map((posting) => ({
+            accountId: posting.accountId,
+            amountCents: BigInt(posting.amountCents).toString(),
+            memo: posting.memo ?? null,
+          })),
+          analytics: input.analyticsPayload ?? null,
+        },
+        labels: {
+          created: result.created,
+          type: input.type,
+        },
+      });
+    } catch (error) {
+      console.error(
+        "Failed to emit ledger journal analytics event", // eslint-disable-line no-console
+        error,
+      );
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary
- add ledger and policy analytics emitters plus append-only Prisma tables for events and feature snapshots
- wrap ledger ingestion in a helper so ingestion services automatically produce analytics events
- implement a worker ETL job that aggregates historical features and update policy tests to cover analytics logging
- document the analytics schema and wire up automated data-quality checks

## Testing
- pnpm lint:markdown *(fails: Command "markdownlint" not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb9874a7c83278022d498ef4f9f60)