### PR TITLE
Add connectors adapters and tax engine endpoints

### DIFF
--- a/services/connectors/src/adapters/payroll.ts
+++ b/services/connectors/src/adapters/payroll.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+
+import type { PaygwCalculationInput, PaygwBracket, TaxEngineClient } from "../tax-engine.js";
+import { roundCurrency } from "../util.js";
+import type {
+  DesignatedAccountCreditor,
+  ObligationEventEnvelope,
+  EventPublisher,
+} from "../types.js";
+
+const DEFAULT_SCHEMA_VERSION = "apgms.obligation.v1";
+const DEFAULT_SUBJECT = "apgms.obligation.calculated";
+const DEFAULT_SOURCE = "adapter/payroll";
+
+export type PayrollEmployee = {
+  employeeId: string;
+  taxableIncome: number;
+  reference?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type PayrollPayload = {
+  orgId: string;
+  payrollRunId: string;
+  payPeriod: { start: string; end: string };
+  occurredAt?: string;
+  employees: ReadonlyArray<PayrollEmployee>;
+  metadata?: Record<string, unknown>;
+};
+
+export type PayrollAdapterDependencies = {
+  taxEngine: TaxEngineClient;
+  paygwBrackets: ReadonlyArray<PaygwBracket>;
+  publisher: EventPublisher;
+  subject?: string;
+  schemaVersion?: string;
+  source?: string;
+  idFactory?: () => string;
+  clock?: () => Date;
+  designatedAccountCredit?: DesignatedAccountCreditor;
+  actorId?: string;
+};
+
+export async function ingestPayrollRun(
+  payload: PayrollPayload,
+  deps: PayrollAdapterDependencies,
+): Promise<ObligationEventEnvelope> {
+  if (!deps.paygwBrackets || deps.paygwBrackets.length === 0) {
+    throw new Error("paygw brackets are required");
+  }
+
+  const idFactory = deps.idFactory ?? randomUUID;
+  const nowIso = (deps.clock?.() ?? new Date()).toISOString();
+  const occurredAt = payload.occurredAt ?? nowIso;
+
+  const lineResults = await Promise.all(
+    payload.employees.map(async (line) => {
+      const taxableIncome = Math.max(0, roundCurrency(line.taxableIncome));
+      if (taxableIncome <= 0) {
+        return { reference: line.reference ?? line.employeeId, basis: 0, withheld: 0 };
+      }
+
+      const request: PaygwCalculationInput = {
+        taxableIncome,
+        brackets: deps.paygwBrackets,
+      };
+      const result = await deps.taxEngine.calculatePaygw(request);
+      return {
+        reference: line.reference ?? line.employeeId,
+        basis: taxableIncome,
+        withheld: roundCurrency(result.withheld),
+      };
+    }),
+  );
+
+  const basisAmount = lineResults.reduce((acc, line) => acc + line.basis, 0);
+  const obligationAmount = lineResults.reduce((acc, line) => acc + line.withheld, 0);
+  const roundedBasis = roundCurrency(basisAmount);
+  const roundedObligation = roundCurrency(obligationAmount);
+  const effectiveRate = basisAmount > 0 ? obligationAmount / basisAmount : 0;
+
+  const envelope: ObligationEventEnvelope = {
+    id: idFactory(),
+    dedupeId: idFactory(),
+    orgId: payload.orgId,
+    eventType: "obligation.calculated",
+    key: `${payload.orgId}:${payload.payrollRunId}`,
+    schemaVersion: deps.schemaVersion ?? DEFAULT_SCHEMA_VERSION,
+    source: deps.source ?? DEFAULT_SOURCE,
+    ts: nowIso,
+    payload: {
+      obligationType: "PAYGW",
+      obligationAmount: roundedObligation,
+      basisAmount: roundedBasis,
+      netOfTax: roundCurrency(roundedBasis - roundedObligation),
+      effectiveRate,
+      sourceSystem: "PAYROLL",
+      reference: payload.payrollRunId,
+      occurredAt,
+      metadata: {
+        employeeCount: payload.employees.length,
+        payPeriod: payload.payPeriod,
+        ...payload.metadata,
+      },
+      breakdown: {
+        lineItems: lineResults.map((line) => ({
+          reference: line.reference,
+          basisAmount: roundCurrency(line.basis),
+          obligationAmount: roundCurrency(line.withheld),
+        })),
+      },
+    },
+  };
+
+  await deps.publisher.publish(deps.subject ?? DEFAULT_SUBJECT, envelope);
+
+  if (deps.designatedAccountCredit && roundedObligation > 0) {
+    await deps.designatedAccountCredit({
+      orgId: payload.orgId,
+      accountType: "PAYGW",
+      amount: roundedObligation,
+      source: "PAYROLL_CAPTURE",
+      actorId: deps.actorId ?? "system",
+    });
+  }
+
+  return envelope;
+}

--- a/services/connectors/src/adapters/pos.ts
+++ b/services/connectors/src/adapters/pos.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+
+import type { TaxEngineClient } from "../tax-engine.js";
+import { roundCurrency } from "../util.js";
+import type {
+  DesignatedAccountCreditor,
+  EventPublisher,
+  ObligationEventEnvelope,
+} from "../types.js";
+
+const DEFAULT_SCHEMA_VERSION = "apgms.obligation.v1";
+const DEFAULT_SUBJECT = "apgms.obligation.calculated";
+const DEFAULT_SOURCE = "adapter/pos";
+
+export type PosSaleClassification = "taxable" | "gst_free" | "input_taxed";
+
+export type PosSale = {
+  saleId: string;
+  total: number;
+  classification?: PosSaleClassification;
+  reference?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type PosPayload = {
+  orgId: string;
+  batchId: string;
+  occurredAt?: string;
+  sales: ReadonlyArray<PosSale>;
+  metadata?: Record<string, unknown>;
+};
+
+export type PosAdapterDependencies = {
+  taxEngine: TaxEngineClient;
+  publisher: EventPublisher;
+  subject?: string;
+  schemaVersion?: string;
+  source?: string;
+  idFactory?: () => string;
+  clock?: () => Date;
+  gstRate?: number;
+  designatedAccountCredit?: DesignatedAccountCreditor;
+  actorId?: string;
+};
+
+export async function ingestPosBatch(
+  payload: PosPayload,
+  deps: PosAdapterDependencies,
+): Promise<ObligationEventEnvelope> {
+  const idFactory = deps.idFactory ?? randomUUID;
+  const nowIso = (deps.clock?.() ?? new Date()).toISOString();
+  const occurredAt = payload.occurredAt ?? nowIso;
+  const gstRate = deps.gstRate ?? 0.1;
+
+  const lineResults = await Promise.all(
+    payload.sales.map(async (sale) => {
+      const classification: PosSaleClassification = sale.classification ?? "taxable";
+      const gross = roundCurrency(sale.total);
+      if (gross <= 0) {
+        return {
+          reference: sale.reference ?? sale.saleId,
+          basis: 0,
+          gst: 0,
+          net: 0,
+          classification,
+        };
+      }
+
+      if (classification !== "taxable") {
+        return {
+          reference: sale.reference ?? sale.saleId,
+          basis: gross,
+          gst: 0,
+          net: gross,
+          classification,
+        };
+      }
+
+      const result = await deps.taxEngine.calculateGst({ amount: gross, rate: gstRate });
+      return {
+        reference: sale.reference ?? sale.saleId,
+        basis: gross,
+        gst: roundCurrency(result.gstPortion),
+        net: roundCurrency(result.netOfGst),
+        classification,
+      };
+    }),
+  );
+
+  const taxableLines = lineResults.filter((line) => line.classification === "taxable");
+  const basisAmount = taxableLines.reduce((acc, line) => acc + line.basis, 0);
+  const obligationAmount = taxableLines.reduce((acc, line) => acc + line.gst, 0);
+  const netOfTaxTotal = taxableLines.reduce((acc, line) => acc + line.net, 0);
+
+  const roundedBasis = roundCurrency(basisAmount);
+  const roundedObligation = roundCurrency(obligationAmount);
+  const roundedNet = roundCurrency(netOfTaxTotal);
+  const effectiveRate = basisAmount > 0 ? obligationAmount / basisAmount : 0;
+
+  const envelope: ObligationEventEnvelope = {
+    id: idFactory(),
+    dedupeId: idFactory(),
+    orgId: payload.orgId,
+    eventType: "obligation.calculated",
+    key: `${payload.orgId}:${payload.batchId}`,
+    schemaVersion: deps.schemaVersion ?? DEFAULT_SCHEMA_VERSION,
+    source: deps.source ?? DEFAULT_SOURCE,
+    ts: nowIso,
+    payload: {
+      obligationType: "GST",
+      obligationAmount: roundedObligation,
+      basisAmount: roundedBasis,
+      netOfTax: roundedNet,
+      effectiveRate,
+      sourceSystem: "POS",
+      reference: payload.batchId,
+      occurredAt,
+      metadata: {
+        saleCount: payload.sales.length,
+        taxableCount: taxableLines.length,
+        gstRate,
+        ...payload.metadata,
+      },
+      breakdown: {
+        lineItems: lineResults.map((line) => ({
+          reference: line.reference,
+          basisAmount: roundCurrency(line.basis),
+          obligationAmount: roundCurrency(line.gst),
+          metadata: { classification: line.classification },
+        })),
+      },
+    },
+  };
+
+  await deps.publisher.publish(deps.subject ?? DEFAULT_SUBJECT, envelope);
+
+  if (deps.designatedAccountCredit && roundedObligation > 0) {
+    await deps.designatedAccountCredit({
+      orgId: payload.orgId,
+      accountType: "GST",
+      amount: roundedObligation,
+      source: "GST_CAPTURE",
+      actorId: deps.actorId ?? "system",
+    });
+  }
+
+  return envelope;
+}

--- a/services/connectors/src/designated.ts
+++ b/services/connectors/src/designated.ts
@@ -1,0 +1,21 @@
+import type {
+  CreditDesignatedAccountInput as DomainCreditInput,
+} from "../../../domain/policy/designated-accounts.js";
+import { creditDesignatedAccountForObligation } from "../../../domain/policy/designated-accounts.js";
+
+import type { DesignatedAccountCreditor, DesignatedAccountCreditInput } from "./types.js";
+
+export function createPolicyDesignatedAccountCreditor(
+  context: Parameters<typeof creditDesignatedAccountForObligation>[0],
+): DesignatedAccountCreditor<Awaited<ReturnType<typeof creditDesignatedAccountForObligation>>> {
+  return (input: DesignatedAccountCreditInput) => {
+    const domainInput: DomainCreditInput = {
+      orgId: input.orgId,
+      accountType: input.accountType,
+      amount: input.amount,
+      source: input.source,
+      actorId: input.actorId,
+    };
+    return creditDesignatedAccountForObligation(context, domainInput);
+  };
+}

--- a/services/connectors/src/index.ts
+++ b/services/connectors/src/index.ts
@@ -1,1 +1,6 @@
-﻿console.log('connectors service');
+export * from "./types.js";
+export * from "./tax-engine.js";
+export * from "./util.js";
+export * from "./adapters/payroll.js";
+export * from "./adapters/pos.js";
+export * from "./designated.js";

--- a/services/connectors/src/tax-engine.ts
+++ b/services/connectors/src/tax-engine.ts
@@ -1,0 +1,130 @@
+export type PaygwBracket = {
+  threshold: number | null;
+  rate: number;
+  base: number;
+};
+
+export type PaygwCalculationInput = {
+  taxableIncome: number;
+  brackets: ReadonlyArray<PaygwBracket>;
+};
+
+export type PaygwCalculationResult = {
+  withheld: number;
+  effectiveRate: number;
+};
+
+export type GstCalculationInput = {
+  amount: number;
+  rate?: number;
+};
+
+export type GstCalculationResult = {
+  gstPortion: number;
+  netOfGst: number;
+};
+
+export interface TaxEngineClient {
+  calculatePaygw(input: PaygwCalculationInput): Promise<PaygwCalculationResult>;
+  calculateGst(input: GstCalculationInput): Promise<GstCalculationResult>;
+}
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+export type HttpTaxEngineClientOptions = {
+  baseUrl: string;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+};
+
+export class HttpTaxEngineClient implements TaxEngineClient {
+  #baseUrl: string;
+  #fetchImpl: FetchLike;
+  #timeoutMs: number;
+
+  constructor(options: HttpTaxEngineClientOptions) {
+    this.#baseUrl = options.baseUrl.replace(/\/$/, "");
+    if (!options.fetchImpl && typeof (globalThis as any).fetch !== "function") {
+      throw new Error("global fetch is not available; provide fetchImpl");
+    }
+    this.#fetchImpl = (options.fetchImpl ?? ((globalThis as any).fetch.bind(globalThis) as FetchLike));
+    this.#timeoutMs = options.timeoutMs ?? 5_000;
+  }
+
+  async calculatePaygw(input: PaygwCalculationInput): Promise<PaygwCalculationResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.#timeoutMs);
+    try {
+      const response = await this.#fetchImpl(`${this.#baseUrl}/v1/paygw`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          taxable_income: input.taxableIncome,
+          brackets: input.brackets.map((bracket) => ({
+            threshold: bracket.threshold,
+            rate: bracket.rate,
+            base: bracket.base,
+          })),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`tax engine paygw request failed (${response.status})`);
+      }
+
+      const payload = (await response.json()) as {
+        withheld: number;
+        effective_rate: number;
+      };
+
+      return {
+        withheld: payload.withheld,
+        effectiveRate: payload.effective_rate,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async calculateGst(input: GstCalculationInput): Promise<GstCalculationResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.#timeoutMs);
+    try {
+      const response = await this.#fetchImpl(`${this.#baseUrl}/v1/gst`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ amount: input.amount, rate: input.rate }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`tax engine gst request failed (${response.status})`);
+      }
+
+      const payload = (await response.json()) as {
+        gst_portion: number;
+        net_of_gst: number;
+      };
+
+      return {
+        gstPortion: payload.gst_portion,
+        netOfGst: payload.net_of_gst,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/services/connectors/src/types.ts
+++ b/services/connectors/src/types.ts
@@ -1,0 +1,42 @@
+import type { BusEnvelope } from "@apgms/shared";
+import type { DesignatedAccountType, DesignatedTransferSource } from "@apgms/shared/ledger";
+
+export type ObligationType = "PAYGW" | "GST";
+
+export type ObligationCalculatedPayload = {
+  obligationType: ObligationType;
+  obligationAmount: number;
+  basisAmount: number;
+  netOfTax?: number;
+  effectiveRate: number;
+  sourceSystem: "PAYROLL" | "POS";
+  reference: string;
+  occurredAt: string;
+  metadata: Record<string, unknown>;
+  breakdown?: {
+    lineItems: Array<{
+      reference: string;
+      basisAmount: number;
+      obligationAmount: number;
+      metadata?: Record<string, unknown>;
+    }>;
+  };
+};
+
+export type ObligationEventEnvelope = BusEnvelope<ObligationCalculatedPayload>;
+
+export interface EventPublisher {
+  publish<T>(subject: string, envelope: BusEnvelope<T>): Promise<void>;
+}
+
+export type DesignatedAccountCreditInput = {
+  orgId: string;
+  accountType: DesignatedAccountType;
+  amount: number;
+  source: DesignatedTransferSource;
+  actorId: string;
+};
+
+export type DesignatedAccountCreditor = <TResult = unknown>(
+  input: DesignatedAccountCreditInput,
+) => Promise<TResult>;

--- a/services/connectors/src/util.ts
+++ b/services/connectors/src/util.ts
@@ -1,0 +1,7 @@
+export function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export function ensurePositive(value: number): number {
+  return roundCurrency(Math.max(0, value));
+}

--- a/services/connectors/test/adapters.spec.ts
+++ b/services/connectors/test/adapters.spec.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ingestPayrollRun } from "../src/adapters/payroll.js";
+import { ingestPosBatch } from "../src/adapters/pos.js";
+import type { EventPublisher, DesignatedAccountCreditor, DesignatedAccountCreditInput } from "../src/types.js";
+import type { TaxEngineClient } from "../src/tax-engine.js";
+
+const stubTaxEngine: TaxEngineClient = {
+  async calculatePaygw({ taxableIncome }) {
+    const withheld = Math.round(taxableIncome * 0.2 * 100) / 100;
+    return { withheld, effectiveRate: taxableIncome > 0 ? withheld / taxableIncome : 0 };
+  },
+  async calculateGst({ amount, rate = 0.1 }) {
+    if (amount <= 0 || rate <= 0) {
+      return { gstPortion: 0, netOfGst: amount };
+    }
+    const divisor = 1 + rate;
+    const net = amount / divisor;
+    const gst = amount - net;
+    return {
+      gstPortion: Math.round(gst * 100) / 100,
+      netOfGst: Math.round(net * 100) / 100,
+    };
+  },
+};
+
+test("payroll adapter emits obligation event and credits PAYGW account", async () => {
+  const published: Array<{ subject: string; key: string }> = [];
+  const credits: DesignatedAccountCreditInput[] = [];
+
+  const publisher: EventPublisher = {
+    async publish(subject, envelope) {
+      published.push({ subject, key: envelope.key });
+    },
+  };
+
+  const designatedAccountCredit: DesignatedAccountCreditor = async (input) => {
+    credits.push(input);
+    return Promise.resolve({});
+  };
+
+  const envelope = await ingestPayrollRun(
+    {
+      orgId: "org-1",
+      payrollRunId: "run-123",
+      payPeriod: { start: "2025-01-01", end: "2025-01-15" },
+      employees: [
+        { employeeId: "emp-1", taxableIncome: 2_000 },
+        { employeeId: "emp-2", taxableIncome: 1_200 },
+      ],
+    },
+    {
+      taxEngine: stubTaxEngine,
+      paygwBrackets: [
+        { threshold: 5_000, rate: 0.2, base: 0 },
+        { threshold: null, rate: 0.3, base: 50 },
+      ],
+      publisher,
+      designatedAccountCredit,
+      actorId: "adapter",
+      idFactory: () => "evt-1",
+      clock: () => new Date("2025-01-16T00:00:00Z"),
+    },
+  );
+
+  assert.equal(envelope.payload.obligationType, "PAYGW");
+  assert.equal(envelope.payload.obligationAmount, 640);
+  assert.equal(envelope.payload.metadata.employeeCount, 2);
+  assert.equal(published.length, 1);
+  assert.equal(published[0].subject, "apgms.obligation.calculated");
+  assert.equal(published[0].key, "org-1:run-123");
+  assert.equal(credits.length, 1);
+  assert.deepEqual(credits[0], {
+    orgId: "org-1",
+    accountType: "PAYGW",
+    amount: 640,
+    source: "PAYROLL_CAPTURE",
+    actorId: "adapter",
+  });
+});
+
+test("pos adapter emits GST obligation and credits GST account", async () => {
+  const published: Array<{ subject: string; key: string }> = [];
+  const credits: DesignatedAccountCreditInput[] = [];
+
+  const publisher: EventPublisher = {
+    async publish(subject, envelope) {
+      published.push({ subject, key: envelope.key });
+    },
+  };
+
+  const designatedAccountCredit: DesignatedAccountCreditor = async (input) => {
+    credits.push(input);
+    return Promise.resolve({});
+  };
+
+  const envelope = await ingestPosBatch(
+    {
+      orgId: "org-1",
+      batchId: "batch-9",
+      sales: [
+        { saleId: "sale-1", total: 110, classification: "taxable" },
+        { saleId: "sale-2", total: 55, classification: "gst_free" },
+      ],
+    },
+    {
+      taxEngine: stubTaxEngine,
+      publisher,
+      designatedAccountCredit,
+      actorId: "adapter",
+      idFactory: () => "evt-2",
+      clock: () => new Date("2025-01-17T00:00:00Z"),
+      gstRate: 0.1,
+    },
+  );
+
+  assert.equal(envelope.payload.obligationType, "GST");
+  assert.equal(envelope.payload.obligationAmount, 10);
+  assert.equal(envelope.payload.metadata.taxableCount, 1);
+  assert.equal(envelope.payload.breakdown?.lineItems.length, 2);
+  assert.equal(published.length, 1);
+  assert.equal(credits.length, 1);
+  assert.deepEqual(credits[0], {
+    orgId: "org-1",
+    accountType: "GST",
+    amount: 10,
+    source: "GST_CAPTURE",
+    actorId: "adapter",
+  });
+});

--- a/services/tax-engine/app/main.py
+++ b/services/tax-engine/app/main.py
@@ -1,5 +1,108 @@
-﻿from fastapi import FastAPI
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, ValidationError, root_validator
+
 app = FastAPI()
-@app.get('/health')
+
+
+class GstRequest(BaseModel):
+    amount: float = Field(..., description="Gross amount that may include GST")
+    rate: Optional[float] = Field(
+        0.1,
+        description="GST rate as a decimal (defaults to 10%)",
+    )
+
+
+class GstResponse(BaseModel):
+    gst_portion: float
+    net_of_gst: float
+
+
+class PaygwBracket(BaseModel):
+    threshold: Optional[float] = Field(
+        None,
+        description="Inclusive upper bound for the bracket. Null represents no upper bound.",
+    )
+    rate: float = Field(..., ge=0)
+    base: float = Field(...)
+
+
+class PaygwRequest(BaseModel):
+    taxable_income: float = Field(..., ge=0, description="Taxable income for the pay period")
+    brackets: List[PaygwBracket] = Field(
+        ..., description="Bracket table ordered by ascending threshold"
+    )
+
+    @root_validator
+    def ensure_brackets(cls, values):  # type: ignore[override]
+        brackets = values.get("brackets")
+        if not brackets:
+            raise ValueError("At least one bracket must be provided")
+        return values
+
+
+class PaygwResponse(BaseModel):
+    withheld: float
+    effective_rate: float
+
+
+@app.get("/health")
 def health():
-    return {'ok': True}
+    return {"ok": True}
+
+
+@app.post("/v1/gst", response_model=GstResponse)
+async def calculate_gst_endpoint(payload: GstRequest) -> GstResponse:
+    if payload.amount <= 0 or (payload.rate is not None and payload.rate <= 0):
+        return GstResponse(gst_portion=0.0, net_of_gst=payload.amount)
+
+    rate = payload.rate if payload.rate is not None else 0.1
+    divisor = 1 + rate
+    net_of_gst = payload.amount / divisor
+    gst_portion = payload.amount - net_of_gst
+    return GstResponse(
+        gst_portion=_round_currency(gst_portion),
+        net_of_gst=_round_currency(net_of_gst),
+    )
+
+
+@app.post("/v1/paygw", response_model=PaygwResponse)
+async def calculate_paygw_endpoint(payload: PaygwRequest) -> PaygwResponse:
+    if payload.taxable_income <= 0:
+        return PaygwResponse(withheld=0.0, effective_rate=0.0)
+
+    try:
+        withheld = _calculate_paygw(payload.taxable_income, payload.brackets)
+    except ValidationError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    effective_rate = min(1.0, withheld / payload.taxable_income)
+    return PaygwResponse(
+        withheld=_round_currency(withheld),
+        effective_rate=effective_rate,
+    )
+
+
+def _calculate_paygw(taxable_income: float, brackets: List[PaygwBracket]) -> float:
+    sorted_brackets = sorted(
+        brackets,
+        key=lambda item: float("inf") if item.threshold is None else item.threshold,
+    )
+
+    withheld = 0.0
+    for bracket in sorted_brackets:
+        withheld = max(0.0, bracket.base + bracket.rate * taxable_income)
+        threshold = float("inf") if bracket.threshold is None else bracket.threshold
+        if taxable_income <= threshold:
+            break
+
+    return withheld
+
+
+def _round_currency(value: float) -> float:
+    decimal_value = Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return float(decimal_value)

--- a/tests/contract/designated-account-credits.spec.ts
+++ b/tests/contract/designated-account-credits.spec.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Prisma } from "@prisma/client";
+
+import {
+  creditDesignatedAccountForObligation,
+  type CreditDesignatedAccountInput,
+} from "../../domain/policy/designated-accounts.js";
+
+type DesignatedAccountState = {
+  id: string;
+  orgId: string;
+  type: string;
+  balance: Prisma.Decimal;
+  updatedAt: Date;
+};
+
+type DesignatedTransferState = {
+  id: string;
+  orgId: string;
+  accountId: string;
+  amount: Prisma.Decimal;
+  source: string;
+  createdAt: Date;
+};
+
+type InMemoryState = {
+  accounts: DesignatedAccountState[];
+  transfers: DesignatedTransferState[];
+  alerts: Array<{ orgId: string; type: string }>;
+  auditLogs: Array<{ action: string; metadata: Record<string, unknown> }>;
+};
+
+function createInMemoryPrisma() {
+  const state: InMemoryState = {
+    accounts: [],
+    transfers: [],
+    alerts: [],
+    auditLogs: [],
+  };
+
+  const prisma = {
+    designatedAccount: {
+      findFirst: async ({ where }: any) => {
+        const match = state.accounts.find(
+          (account) => account.orgId === where.orgId && account.type === where.type,
+        );
+        return match ? { ...match } : null;
+      },
+      findUnique: async ({ where }: any) => {
+        const match = state.accounts.find((account) => account.id === where.id);
+        return match ? { ...match } : null;
+      },
+      update: async ({ where, data }: any) => {
+        const account = state.accounts.find((entry) => entry.id === where.id);
+        if (!account) throw new Error("account not found");
+        if (data.balance) account.balance = data.balance;
+        if (data.updatedAt) account.updatedAt = data.updatedAt;
+        return { ...account };
+      },
+    },
+    designatedTransfer: {
+      create: async ({ data }: any) => {
+        const transfer: DesignatedTransferState = {
+          id: data.id ?? `xfer-${state.transfers.length + 1}`,
+          orgId: data.orgId,
+          accountId: data.accountId,
+          amount: data.amount,
+          source: data.source,
+          createdAt: data.createdAt ?? new Date(),
+        };
+        state.transfers.push(transfer);
+        return { ...transfer };
+      },
+    },
+    alert: {
+      findFirst: async () => null,
+      create: async ({ data }: any) => {
+        state.alerts.push({ orgId: data.orgId, type: data.type });
+        return { ...data, id: data.id ?? `alert-${state.alerts.length}` };
+      },
+    },
+    auditLog: {
+      create: async ({ data }: any) => {
+        state.auditLogs.push({ action: data.action, metadata: data.metadata ?? {} });
+        return { ...data, id: data.id ?? `audit-${state.auditLogs.length}` };
+      },
+    },
+    $transaction: async (callback: (tx: any) => Promise<unknown>) => callback(prisma),
+  };
+
+  return { prisma, state };
+}
+
+test("credits PAYGW and GST obligations into designated accounts", async () => {
+  const { prisma, state } = createInMemoryPrisma();
+
+  state.accounts.push(
+    {
+      id: "acct-paygw",
+      orgId: "org-1",
+      type: "PAYGW",
+      balance: new Prisma.Decimal(0),
+      updatedAt: new Date(),
+    },
+    {
+      id: "acct-gst",
+      orgId: "org-1",
+      type: "GST",
+      balance: new Prisma.Decimal(0),
+      updatedAt: new Date(),
+    },
+  );
+
+  const context = {
+    prisma: prisma as any,
+    auditLogger: async (entry: any) => {
+      await prisma.auditLog.create({ data: entry });
+    },
+  };
+
+  const paygwInput: CreditDesignatedAccountInput = {
+    orgId: "org-1",
+    accountType: "PAYGW",
+    amount: 640,
+    source: "PAYROLL_CAPTURE",
+    actorId: "adapter",
+  };
+
+  const gstInput: CreditDesignatedAccountInput = {
+    orgId: "org-1",
+    accountType: "GST",
+    amount: 10,
+    source: "GST_CAPTURE",
+    actorId: "adapter",
+  };
+
+  const paygwResult = await creditDesignatedAccountForObligation(context, paygwInput);
+  const gstResult = await creditDesignatedAccountForObligation(context, gstInput);
+
+  assert.equal(paygwResult.newBalance, 640);
+  assert.equal(gstResult.newBalance, 10);
+  assert.equal(state.transfers.length, 2);
+  assert.equal(state.transfers[0].source, "PAYROLL_CAPTURE");
+  assert.equal(state.transfers[1].source, "GST_CAPTURE");
+  assert.equal(state.auditLogs.filter((entry) => entry.action === "designatedAccount.credit").length, 2);
+});
+
+test("throws when designated account for obligation is missing", async () => {
+  const { prisma } = createInMemoryPrisma();
+  const context = { prisma: prisma as any };
+
+  await assert.rejects(
+    () =>
+      creditDesignatedAccountForObligation(context, {
+        orgId: "org-2",
+        accountType: "GST",
+        amount: 100,
+        source: "GST_CAPTURE",
+        actorId: "tester",
+      }),
+    (error: any) => error?.code === "designated_account_not_found",
+  );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
                             "outDir":  "dist",
                             "baseUrl":  ".",
                             "paths":  {
+                                          "@apgms/shared":  [
+                                                                  "shared/src/index.ts"
+                                                              ],
                                           "@apgms/shared/*":  [
                                                                   "shared/src/*"
                                                               ]


### PR DESCRIPTION
## Summary
- add payroll and POS ingestion adapters that normalize obligation events and optionally credit designated accounts
- expose PAYGW and GST calculation endpoints from the tax engine FastAPI service for reuse by adapters
- provide a designated account credit helper plus contract coverage for PAYGW and GST flows

## Testing
- pnpm exec tsx --test services/connectors/test/adapters.spec.ts
- pnpm exec tsx --test tests/contract/designated-account-credits.spec.ts
- pytest *(fails: existing payg_resolver dataset only covers sub-$1k incomes so assertions for higher brackets do not match)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911a4f356b48327957283763ff6a98d)