### PR TITLE
Automate ML retraining and tighten retention controls

### DIFF
--- a/.github/workflows/ml_retrain.yml
+++ b/.github/workflows/ml_retrain.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           node scripts/ml-retrain.mjs
       - name: Upload latest model metadata
-        if: ${{ always() && exists('artifacts/ml/model-metadata.json') }}
+        if: ${{ always() && hashFiles('artifacts/ml/model-metadata.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ml-model-metadata


### PR DESCRIPTION
## Summary
- add an automated GitHub Actions workflow and orchestration script to retrain the model whenever new training data lands
- publish retraining metadata plus drift/accuracy telemetry from services/ml-inference for dashboard consumption
- document ML governance policies and update data deletion logic to respect retention-driven anonymisation

## Testing
- `ML_RETRAIN_COMMAND="node services/ml-inference/pipeline/retrain.mjs" node scripts/ml-retrain.mjs`
- `node --test services/api-gateway/test/admin.data.delete.spec.js` *(fails: ESM resolver cannot locate module without ts build step)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911abe109148327b40be97d2e34245f)