### PR TITLE
feat: add model-service data pipelines

### DIFF
--- a/packages/model-service/README.md
+++ b/packages/model-service/README.md
@@ -1,0 +1,37 @@
+# @apgms/model-service
+
+Data preparation utilities and feature engineering pipelines for analytical models. The package
+focuses on extracting payroll and ledger data from the operational datastore and producing audit-
+ready artifacts for downstream model training.
+
+## Available scripts
+
+### Inspect Prisma schema
+
+```
+pnpm --filter @apgms/model-service data:inspect
+```
+
+Parses `shared/prisma/schema.prisma` and emits a dataset manifest describing which models and
+fields feed each analytical dataset. The manifest is stored in
+`packages/model-service/artifacts/dataset-manifest.json`.
+
+### Export payroll dataset
+
+```
+pnpm --filter @apgms/model-service data:export:payroll -- --source prisma --output ./artifacts/payroll.json
+```
+
+Combines employees, pay runs, and payslips into a single JSON payload that can be consumed by the
+feature pipeline. Use `--source exports` to load from `data/external/payroll/*.json` exports instead
+of a live database. Pass `--include-sensitive` to include encrypted name fields when permissible.
+
+### Generate payroll features
+
+```
+pnpm --filter @apgms/model-service pipeline:payroll -- --input ./artifacts/payroll.json --output ./artifacts/features
+```
+
+Produces reproducible feature tables with normalization metadata. The pipeline outputs raw and
+normalized CSVs along with a JSON metadata file capturing the schema, record counts, and statistics
+required for audit trails.

--- a/packages/model-service/artifacts/dataset-manifest.json
+++ b/packages/model-service/artifacts/dataset-manifest.json
@@ -1,0 +1,963 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2025-11-10T09:18:01.095Z",
+  "source": "shared/prisma/schema.prisma",
+  "datasets": [
+    {
+      "name": "payroll_core",
+      "description": "Employees, pay runs, and payslips needed for payroll analytics.",
+      "models": [
+        {
+          "name": "Employee",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "org",
+              "type": "Org",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[orgId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            },
+            {
+              "name": "fullNameCiphertext",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "fullNameKid",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "tfnProvided",
+              "type": "Boolean",
+              "isList": false,
+              "attributes": [
+                "@default(false)"
+              ]
+            },
+            {
+              "name": "employmentType",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "baseRate",
+              "type": "Decimal",
+              "isList": false,
+              "attributes": [
+                "@db.Decimal(12,",
+                "2)",
+                "@default(\"0\")"
+              ]
+            },
+            {
+              "name": "superRate",
+              "type": "Decimal",
+              "isList": false,
+              "attributes": [
+                "@db.Decimal(5,",
+                "2)",
+                "@default(\"11.0\")"
+              ]
+            },
+            {
+              "name": "status",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@default(\"active\")"
+              ]
+            },
+            {
+              "name": "createdAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            },
+            {
+              "name": "payslips",
+              "type": "Payslip",
+              "isList": true,
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "name": "PayRun",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "org",
+              "type": "Org",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[orgId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            },
+            {
+              "name": "periodStart",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "periodEnd",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "paymentDate",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "status",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@default(\"draft\")"
+              ]
+            },
+            {
+              "name": "createdAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            },
+            {
+              "name": "payslips",
+              "type": "Payslip",
+              "isList": true,
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "name": "Payslip",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id"
+              ]
+            },
+            {
+              "name": "payRunId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "payRun",
+              "type": "PayRun",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[payRunId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            },
+            {
+              "name": "employeeId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "employee",
+              "type": "Employee",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[employeeId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            },
+            {
+              "name": "grossPay",
+              "type": "Decimal",
+              "isList": false,
+              "attributes": [
+                "@db.Decimal(12,",
+                "2)"
+              ]
+            },
+            {
+              "name": "paygWithheld",
+              "type": "Decimal",
+              "isList": false,
+              "attributes": [
+                "@db.Decimal(12,",
+                "2)"
+              ]
+            },
+            {
+              "name": "superAccrued",
+              "type": "Decimal",
+              "isList": false,
+              "attributes": [
+                "@db.Decimal(12,",
+                "2)"
+              ]
+            },
+            {
+              "name": "notesCiphertext",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "notesKid",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "createdAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "PayrollItem",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "employeeId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "payPeriodStart",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "payPeriodEnd",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "grossCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "paygwCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "stslCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "journalId",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ledger_core",
+      "description": "Core double-entry ledger postings, balances, and journals.",
+      "models": [
+        {
+          "name": "Organization",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "name",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "createdAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            },
+            {
+              "name": "accounts",
+              "type": "Account",
+              "isList": true,
+              "attributes": []
+            },
+            {
+              "name": "journals",
+              "type": "Journal",
+              "isList": true,
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "name": "Account",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "code",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "name",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "type",
+              "type": "AccountType",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "subtype",
+              "type": "AccountSubtype?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "currency",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@default(\"AUD\")"
+              ]
+            },
+            {
+              "name": "isActive",
+              "type": "Boolean",
+              "isList": false,
+              "attributes": [
+                "@default(true)"
+              ]
+            },
+            {
+              "name": "createdAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            },
+            {
+              "name": "postings",
+              "type": "Posting",
+              "isList": true,
+              "attributes": []
+            },
+            {
+              "name": "balances",
+              "type": "BalanceSnapshot",
+              "isList": true,
+              "attributes": []
+            },
+            {
+              "name": "organization",
+              "type": "Organization",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[orgId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Journal",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "seq",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "type",
+              "type": "JournalType",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "eventId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "dedupeId",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "occurredAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "recordedAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            },
+            {
+              "name": "source",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "description",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "hash",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "prevHash",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "postings",
+              "type": "Posting",
+              "isList": true,
+              "attributes": []
+            },
+            {
+              "name": "organization",
+              "type": "Organization",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[orgId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Posting",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "journalId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "accountId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "amountCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "memo",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "journal",
+              "type": "Journal",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[journalId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            },
+            {
+              "name": "account",
+              "type": "Account",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[accountId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BalanceSnapshot",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "accountId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "asOfSeq",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "balanceCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "createdAt",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": [
+                "@default(now())"
+              ]
+            },
+            {
+              "name": "account",
+              "type": "Account",
+              "isList": false,
+              "attributes": [
+                "@relation(fields:",
+                "[accountId],",
+                "references:",
+                "[id],",
+                "onDelete:",
+                "Cascade)"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "cashflow_support",
+      "description": "Bank and GST transactions used for auxiliary reconciliation.",
+      "models": [
+        {
+          "name": "BankTransaction",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "extRef",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "accountName",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "txDate",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "amountCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "description",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "matchedJournalId",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "name": "GstTransaction",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id",
+                "@default(uuid())",
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "sourceRef",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "txDate",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "netCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "gstCents",
+              "type": "BigInt",
+              "isList": false,
+              "attributes": [
+                "@db.BigInt"
+              ]
+            },
+            {
+              "name": "code",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "basPeriodId",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "name": "EventEnvelope",
+          "fields": [
+            {
+              "name": "id",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@id"
+              ]
+            },
+            {
+              "name": "orgId",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@db.Uuid"
+              ]
+            },
+            {
+              "name": "eventType",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "key",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "ts",
+              "type": "DateTime",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "schemaVersion",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "source",
+              "type": "String",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "traceId",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "payload",
+              "type": "Json",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "processedAt",
+              "type": "DateTime?",
+              "isList": false,
+              "attributes": []
+            },
+            {
+              "name": "status",
+              "type": "String",
+              "isList": false,
+              "attributes": [
+                "@default(\"processed\")"
+              ]
+            },
+            {
+              "name": "error",
+              "type": "String?",
+              "isList": false,
+              "attributes": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/model-service/artifacts/payroll_feature_schema.json
+++ b/packages/model-service/artifacts/payroll_feature_schema.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.1.0",
+  "updatedAt": "2025-11-10T00:00:00.000Z",
+  "fields": [
+    { "name": "employeeId", "type": "string", "description": "Foreign key referencing the employee record." },
+    { "name": "payRunId", "type": "string", "description": "Identifier for the pay run containing the payslip." },
+    { "name": "periodStart", "type": "string", "description": "ISO-8601 timestamp for the start of the pay period." },
+    { "name": "periodEnd", "type": "string", "description": "ISO-8601 timestamp for the end of the pay period." },
+    { "name": "paymentDate", "type": "string", "description": "ISO-8601 timestamp when the payslip was scheduled for payment." },
+    { "name": "grossPay", "type": "number", "description": "Total gross pay for the payslip in AUD." },
+    { "name": "paygWithheld", "type": "number", "description": "Total PAYG withheld amount in AUD." },
+    { "name": "superAccrued", "type": "number", "description": "Total superannuation accrued in AUD." },
+    { "name": "netPay", "type": "number", "description": "Computed net pay in AUD after PAYG withholding." },
+    { "name": "payPeriodDays", "type": "number", "description": "Duration of the pay period in days." },
+    { "name": "grossPerDay", "type": "number", "description": "Average gross pay per day across the period." }
+  ]
+}

--- a/packages/model-service/data/export-payroll-data.ts
+++ b/packages/model-service/data/export-payroll-data.ts
@@ -1,0 +1,218 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PayrollDataset, PayslipRecord, PayRunRecord, EmployeeRecord } from '../src/types.js';
+
+type DataSource = 'prisma' | 'exports';
+
+interface CliOptions {
+  source: DataSource;
+  output: string;
+  includeSensitive: boolean;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../..');
+
+const DEFAULT_EXPORT_PATH = path.join(
+  WORKSPACE_ROOT,
+  'packages/model-service/artifacts/payroll-dataset.json',
+);
+
+async function loadFromPrisma(includeSensitive: boolean): Promise<PayrollDataset> {
+  const prismaModule = (await import('@prisma/client')) as any;
+  const PrismaClient = prismaModule?.PrismaClient ?? prismaModule?.default?.PrismaClient;
+  if (!PrismaClient) {
+    throw new Error('Unable to load PrismaClient from @prisma/client. Run `pnpm db:gen` first.');
+  }
+  const prisma = new PrismaClient();
+  try {
+    const [employees, payRuns, payslips] = await Promise.all([
+      prisma.employee.findMany({
+        select: {
+          id: true,
+          orgId: true,
+          employmentType: true,
+          baseRate: true,
+          superRate: true,
+          status: true,
+          createdAt: true,
+          fullNameCiphertext: includeSensitive,
+          fullNameKid: includeSensitive,
+        },
+      }),
+      prisma.payRun.findMany({
+        select: {
+          id: true,
+          orgId: true,
+          periodStart: true,
+          periodEnd: true,
+          paymentDate: true,
+          status: true,
+          createdAt: true,
+        },
+      }),
+      prisma.payslip.findMany({
+        select: {
+          id: true,
+          payRunId: true,
+          employeeId: true,
+          grossPay: true,
+          paygWithheld: true,
+          superAccrued: true,
+          createdAt: true,
+        },
+      }),
+    ]);
+
+    const normalizeMoney = (value: unknown): number => {
+      if (typeof value === 'number') {
+        return value;
+      }
+      if (typeof value === 'string') {
+        return Number(value);
+      }
+      if (value && typeof (value as { toString: () => string }).toString === 'function') {
+        return Number((value as { toString: () => string }).toString());
+      }
+      throw new TypeError(`Unable to normalize monetary value: ${String(value)}`);
+    };
+
+    const normalizeEmployee = (employee: any): EmployeeRecord => ({
+      id: employee.id,
+      orgId: employee.orgId,
+      employmentType: employee.employmentType,
+      baseRate: normalizeMoney(employee.baseRate),
+      superRate: normalizeMoney(employee.superRate),
+      status: employee.status,
+      createdAt: employee.createdAt.toISOString(),
+    });
+
+    const normalizePayRun = (payRun: any): PayRunRecord => ({
+      id: payRun.id,
+      orgId: payRun.orgId,
+      periodStart: payRun.periodStart.toISOString(),
+      periodEnd: payRun.periodEnd.toISOString(),
+      paymentDate: payRun.paymentDate.toISOString(),
+      status: payRun.status,
+      createdAt: payRun.createdAt.toISOString(),
+    });
+
+    const normalizePayslip = (payslip: any): PayslipRecord => ({
+      id: payslip.id,
+      payRunId: payslip.payRunId,
+      employeeId: payslip.employeeId,
+      grossPay: normalizeMoney(payslip.grossPay),
+      paygWithheld: normalizeMoney(payslip.paygWithheld),
+      superAccrued: normalizeMoney(payslip.superAccrued),
+      createdAt: payslip.createdAt.toISOString(),
+    });
+
+    return {
+      employees: employees.map(normalizeEmployee),
+      payRuns: payRuns.map(normalizePayRun),
+      payslips: payslips.map(normalizePayslip),
+    } satisfies PayrollDataset;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+async function loadFromExports(includeSensitive: boolean): Promise<PayrollDataset> {
+  const baseDir = path.join(WORKSPACE_ROOT, 'data/external/payroll');
+  const employeePath = path.join(baseDir, 'employees.json');
+  const payRunPath = path.join(baseDir, 'payRuns.json');
+  const payslipPath = path.join(baseDir, 'payslips.json');
+
+  const [employeeRaw, payRunRaw, payslipRaw] = await Promise.all([
+    readFile(employeePath, 'utf8'),
+    readFile(payRunPath, 'utf8'),
+    readFile(payslipPath, 'utf8'),
+  ]);
+
+  const dataset = {
+    employees: JSON.parse(employeeRaw),
+    payRuns: JSON.parse(payRunRaw),
+    payslips: JSON.parse(payslipRaw),
+  } as PayrollDataset;
+
+  if (!includeSensitive) {
+    dataset.employees = dataset.employees.map((employee) => ({
+      ...employee,
+      fullNameCiphertext: undefined,
+      fullNameKid: undefined,
+    }));
+  }
+
+  return dataset;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    source: 'prisma',
+    output: DEFAULT_EXPORT_PATH,
+    includeSensitive: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--source': {
+        const value = argv[index + 1];
+        if (value !== 'prisma' && value !== 'exports') {
+          throw new Error('Invalid value for --source. Expected "prisma" or "exports".');
+        }
+        options.source = value;
+        index += 1;
+        break;
+      }
+      case '--output': {
+        options.output = path.resolve(argv[index + 1] ?? DEFAULT_EXPORT_PATH);
+        index += 1;
+        break;
+      }
+      case '--include-sensitive': {
+        options.includeSensitive = true;
+        break;
+      }
+      case '--help':
+      case '-h': {
+        console.log(
+          `Usage: pnpm --filter @apgms/model-service data:export:payroll -- [options]\n\n` +
+            `Options:\n` +
+            `  --source <prisma|exports>   Source of data (default: prisma).\n` +
+            `  --output <path>            Output file path for the combined dataset.\n` +
+            `  --include-sensitive        Include encrypted employee fields if available.\n` +
+            `  --help                     Show this help message.\n`,
+        );
+        process.exit(0);
+      }
+      default:
+        break;
+    }
+  }
+
+  return options;
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const dataset =
+      options.source === 'prisma'
+        ? await loadFromPrisma(options.includeSensitive)
+        : await loadFromExports(options.includeSensitive);
+
+    await mkdir(path.dirname(options.output), { recursive: true });
+    await writeFile(options.output, JSON.stringify(dataset, null, 2), 'utf8');
+    console.log(
+      `Payroll dataset exported using source=\"${options.source}\" to ${options.output}`,
+    );
+  } catch (error) {
+    console.error('[model-service] Failed to export payroll data:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/model-service/data/inspect-prisma-schema.ts
+++ b/packages/model-service/data/inspect-prisma-schema.ts
@@ -1,0 +1,125 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+type FieldDefinition = {
+  name: string;
+  type: string;
+  isList: boolean;
+  attributes: string[];
+};
+
+type ModelDefinition = {
+  name: string;
+  fields: FieldDefinition[];
+};
+
+type DatasetDefinition = {
+  name: string;
+  description: string;
+  models: string[];
+};
+
+const DATASETS: DatasetDefinition[] = [
+  {
+    name: 'payroll_core',
+    description: 'Employees, pay runs, and payslips needed for payroll analytics.',
+    models: ['Employee', 'PayRun', 'Payslip', 'PayrollItem'],
+  },
+  {
+    name: 'ledger_core',
+    description: 'Core double-entry ledger postings, balances, and journals.',
+    models: ['Organization', 'Account', 'Journal', 'Posting', 'BalanceSnapshot'],
+  },
+  {
+    name: 'cashflow_support',
+    description: 'Bank and GST transactions used for auxiliary reconciliation.',
+    models: ['BankTransaction', 'GstTransaction', 'EventEnvelope'],
+  },
+];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../..');
+
+const SCHEMA_PATH = path.join(WORKSPACE_ROOT, 'shared/prisma/schema.prisma');
+const ARTIFACT_DIR = path.join(WORKSPACE_ROOT, 'packages/model-service/artifacts');
+const ARTIFACT_PATH = path.join(ARTIFACT_DIR, 'dataset-manifest.json');
+
+function extractModels(schema: string): ModelDefinition[] {
+  const modelRegex = /model\s+(\w+)\s+\{([\s\S]*?)\n\}/g;
+  const models: ModelDefinition[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = modelRegex.exec(schema)) !== null) {
+    const [, modelName, body] = match;
+    const fields: FieldDefinition[] = [];
+    const lines = body.split('\n');
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('@@')) {
+        continue;
+      }
+
+      const parts = trimmed.split(/\s+/);
+      if (parts.length < 2) {
+        continue;
+      }
+      const [name, rawType, ...attributes] = parts;
+      const isList = rawType.endsWith('[]');
+      const type = isList ? rawType.slice(0, -2) : rawType;
+
+      fields.push({
+        name,
+        type,
+        isList,
+        attributes,
+      });
+    }
+
+    models.push({
+      name: modelName,
+      fields,
+    });
+  }
+
+  return models;
+}
+
+async function main(): Promise<void> {
+  const schemaContents = await readFile(SCHEMA_PATH, 'utf8');
+  const models = extractModels(schemaContents);
+  const lookup = new Map(models.map((model) => [model.name, model]));
+
+  const manifest = {
+    version: '0.1.0',
+    generatedAt: new Date().toISOString(),
+    source: path.relative(WORKSPACE_ROOT, SCHEMA_PATH),
+    datasets: DATASETS.map((dataset) => ({
+      name: dataset.name,
+      description: dataset.description,
+      models: dataset.models
+        .map((modelName) => lookup.get(modelName))
+        .filter((model): model is ModelDefinition => Boolean(model))
+        .map((model) => ({
+          name: model.name,
+          fields: model.fields.map((field) => ({
+            name: field.name,
+            type: field.type,
+            isList: field.isList,
+            attributes: field.attributes,
+          })),
+        })),
+    })),
+  };
+
+  await mkdir(ARTIFACT_DIR, { recursive: true });
+  await writeFile(ARTIFACT_PATH, JSON.stringify(manifest, null, 2), 'utf8');
+  console.log(`Dataset manifest written to ${path.relative(WORKSPACE_ROOT, ARTIFACT_PATH)}`);
+}
+
+main().catch((error) => {
+  console.error('[model-service] Failed to inspect Prisma schema:', error);
+  process.exit(1);
+});

--- a/packages/model-service/package.json
+++ b/packages/model-service/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@apgms/model-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "data:inspect": "tsx data/inspect-prisma-schema.ts",
+    "data:export:payroll": "tsx data/export-payroll-data.ts",
+    "pipeline:payroll": "tsx src/cli/payroll-features.ts"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "@prisma/client": "^6.17.1"
+  }
+}

--- a/packages/model-service/src/cli/payroll-features.ts
+++ b/packages/model-service/src/cli/payroll-features.ts
@@ -1,0 +1,74 @@
+import path from 'path';
+import { runPayrollFeaturePipeline } from '../pipelines/payrollFeaturePipeline.js';
+
+interface CliOptions {
+  input: string;
+  output: string;
+  version?: string;
+}
+
+function printHelp(): void {
+  console.log(`Usage: pnpm --filter @apgms/model-service pipeline:payroll -- [options]\n\n` +
+    `Options:\n` +
+    `  --input <path>     Path to the payroll dataset JSON file.\n` +
+    `  --output <path>    Directory where pipeline outputs will be written.\n` +
+    `  --version <value>  Optional version tag recorded in metadata (default: 0.1.0).\n` +
+    `  --help             Show this help message.\n`);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    input: '',
+    output: path.resolve('packages/model-service/artifacts/pipeline-output'),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--input': {
+        options.input = path.resolve(argv[index + 1] ?? '');
+        index += 1;
+        break;
+      }
+      case '--output': {
+        options.output = path.resolve(argv[index + 1] ?? '');
+        index += 1;
+        break;
+      }
+      case '--version': {
+        options.version = argv[index + 1];
+        index += 1;
+        break;
+      }
+      case '--help':
+      case '-h': {
+        printHelp();
+        process.exit(0);
+      }
+      default:
+        break;
+    }
+  }
+
+  if (!options.input) {
+    throw new Error('Missing required option --input <path>');
+  }
+
+  return options;
+}
+
+async function main(): Promise<void> {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    await runPayrollFeaturePipeline({
+      inputPath: args.input,
+      outputDir: args.output,
+      version: args.version,
+    });
+  } catch (error) {
+    console.error('[model-service] Failed to run payroll pipeline:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/model-service/src/pipelines/payrollFeaturePipeline.ts
+++ b/packages/model-service/src/pipelines/payrollFeaturePipeline.ts
@@ -1,0 +1,223 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  NormalizationStats,
+  PayrollDataset,
+  PayrollFeatureRecord,
+  PipelineMetadata,
+} from '../types.js';
+
+const FEATURE_DESCRIPTIONS: Array<PipelineMetadata['featureSchema'][number]> = [
+  { name: 'employeeId', type: 'string', description: 'Foreign key referencing the employee record.' },
+  { name: 'payRunId', type: 'string', description: 'Identifier for the pay run containing the payslip.' },
+  { name: 'periodStart', type: 'string', description: 'ISO-8601 timestamp for the start of the pay period.' },
+  { name: 'periodEnd', type: 'string', description: 'ISO-8601 timestamp for the end of the pay period.' },
+  { name: 'paymentDate', type: 'string', description: 'ISO-8601 timestamp when the payslip was scheduled for payment.' },
+  { name: 'grossPay', type: 'number', description: 'Total gross pay for the payslip in AUD.' },
+  { name: 'paygWithheld', type: 'number', description: 'Total PAYG withheld amount in AUD.' },
+  { name: 'superAccrued', type: 'number', description: 'Total superannuation accrued in AUD.' },
+  { name: 'netPay', type: 'number', description: 'Computed net pay in AUD after PAYG withholding.' },
+  { name: 'payPeriodDays', type: 'number', description: 'Duration of the pay period in days.' },
+  { name: 'grossPerDay', type: 'number', description: 'Average gross pay per day across the period.' },
+];
+
+export interface PayrollPipelineOptions {
+  inputPath: string;
+  outputDir: string;
+  version?: string;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../..');
+
+function readJsonFile<T>(filePath: string): Promise<T> {
+  return readFile(filePath, 'utf8').then((raw) => JSON.parse(raw) as T);
+}
+
+function ensureNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  if (value && typeof (value as { toString: () => string }).toString === 'function') {
+    const parsed = Number((value as { toString: () => string }).toString());
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  throw new TypeError(`Unable to coerce value \"${String(value)}\" to number.`);
+}
+
+function diffInDays(start: string, end: string): number {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.max(1, Math.round((endDate.getTime() - startDate.getTime()) / msPerDay));
+}
+
+function computeFeatures(dataset: PayrollDataset): PayrollFeatureRecord[] {
+  const payRunIndex = new Map(dataset.payRuns.map((payRun) => [payRun.id, payRun]));
+  return dataset.payslips
+    .map((payslip) => {
+      const payRun = payRunIndex.get(payslip.payRunId);
+      if (!payRun) {
+        return null;
+      }
+
+      const grossPay = ensureNumber(payslip.grossPay);
+      const withheld = ensureNumber(payslip.paygWithheld);
+      const superAccrued = ensureNumber(payslip.superAccrued);
+      const netPay = grossPay - withheld;
+      const periodDays = diffInDays(payRun.periodStart, payRun.periodEnd);
+
+      return {
+        employeeId: payslip.employeeId,
+        payRunId: payslip.payRunId,
+        periodStart: payRun.periodStart,
+        periodEnd: payRun.periodEnd,
+        paymentDate: payRun.paymentDate,
+        grossPay,
+        paygWithheld: withheld,
+        superAccrued,
+        netPay,
+        payPeriodDays: periodDays,
+        grossPerDay: periodDays === 0 ? grossPay : grossPay / periodDays,
+      } satisfies PayrollFeatureRecord;
+    })
+    .filter((record): record is PayrollFeatureRecord => Boolean(record));
+}
+
+function computeNormalization(records: PayrollFeatureRecord[]): NormalizationStats[] {
+  const numericFields: Array<keyof PayrollFeatureRecord> = [
+    'grossPay',
+    'paygWithheld',
+    'superAccrued',
+    'netPay',
+    'payPeriodDays',
+    'grossPerDay',
+  ];
+
+  return numericFields.map((field) => {
+    const values = records.map((record) => record[field] as number);
+    const mean = values.reduce((sum, value) => sum + value, 0) / Math.max(values.length, 1);
+    const variance =
+      values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / Math.max(values.length, 1);
+    const stdDev = Math.sqrt(variance) || 1;
+    const min = values.length === 0 ? 0 : Math.min(...values);
+    const max = values.length === 0 ? 0 : Math.max(...values);
+
+    return {
+      field,
+      mean,
+      stdDev,
+      min,
+      max,
+    } satisfies NormalizationStats;
+  });
+}
+
+function normalizeRecords(
+  records: PayrollFeatureRecord[],
+  stats: NormalizationStats[],
+): PayrollFeatureRecord[] {
+  const lookup = new Map(stats.map((stat) => [stat.field, stat]));
+  return records.map((record) => {
+    const cloned: PayrollFeatureRecord = { ...record };
+    lookup.forEach((stat, field) => {
+      const value = record[field];
+      if (typeof value === 'number') {
+        const normalized = (value - stat.mean) / stat.stdDev;
+        const typedField = field as keyof PayrollFeatureRecord;
+        (cloned as Record<keyof PayrollFeatureRecord, PayrollFeatureRecord[keyof PayrollFeatureRecord]>)[
+          typedField
+        ] = normalized as PayrollFeatureRecord[keyof PayrollFeatureRecord];
+      }
+    });
+    return cloned;
+  });
+}
+
+function toCsv(records: PayrollFeatureRecord[]): string {
+  const headers = [
+    'employeeId',
+    'payRunId',
+    'periodStart',
+    'periodEnd',
+    'paymentDate',
+    'grossPay',
+    'paygWithheld',
+    'superAccrued',
+    'netPay',
+    'payPeriodDays',
+    'grossPerDay',
+  ];
+
+  const lines = [headers.join(',')];
+  for (const record of records) {
+    lines.push(
+      headers
+        .map((header) => {
+          const value = record[header as keyof PayrollFeatureRecord];
+          if (typeof value === 'number') {
+            return value.toFixed(6);
+          }
+          return `"${String(value)}"`;
+        })
+        .join(','),
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runPayrollFeaturePipeline({
+  inputPath,
+  outputDir,
+  version = '0.1.0',
+}: PayrollPipelineOptions): Promise<void> {
+  const absoluteInput = path.resolve(inputPath);
+  const dataset = await readJsonFile<PayrollDataset>(absoluteInput);
+  const features = computeFeatures(dataset);
+  const normalization = computeNormalization(features);
+  const normalizedRecords = normalizeRecords(features, normalization);
+
+  const normalizedCsv = toCsv(normalizedRecords);
+  const rawCsv = toCsv(features);
+
+  await mkdir(outputDir, { recursive: true });
+
+  const rawOutputPath = path.join(outputDir, 'payroll_features.raw.csv');
+  const normalizedOutputPath = path.join(outputDir, 'payroll_features.normalized.csv');
+  const metadataPath = path.join(outputDir, 'payroll_features.metadata.json');
+  const schemaArtifactPath = path.join(
+    WORKSPACE_ROOT,
+    'packages/model-service/artifacts/payroll_feature_schema.json',
+  );
+
+  const metadata: PipelineMetadata = {
+    version,
+    generatedAt: new Date().toISOString(),
+    sourceDataset: absoluteInput,
+    recordCount: features.length,
+    featureSchema: FEATURE_DESCRIPTIONS,
+    normalization,
+  };
+
+  await Promise.all([
+    writeFile(rawOutputPath, rawCsv, 'utf8'),
+    writeFile(normalizedOutputPath, normalizedCsv, 'utf8'),
+    writeFile(metadataPath, JSON.stringify(metadata, null, 2), 'utf8'),
+    writeFile(schemaArtifactPath, JSON.stringify({
+      version,
+      updatedAt: new Date().toISOString(),
+      fields: FEATURE_DESCRIPTIONS,
+    }, null, 2), 'utf8'),
+  ]);
+}

--- a/packages/model-service/src/types.ts
+++ b/packages/model-service/src/types.ts
@@ -1,0 +1,75 @@
+export interface EmployeeRecord {
+  id: string;
+  orgId: string;
+  employmentType: string;
+  baseRate: number;
+  superRate: number;
+  status: string;
+  createdAt: string;
+}
+
+export interface PayRunRecord {
+  id: string;
+  orgId: string;
+  periodStart: string;
+  periodEnd: string;
+  paymentDate: string;
+  status: string;
+  createdAt: string;
+}
+
+export interface PayslipRecord {
+  id: string;
+  payRunId: string;
+  employeeId: string;
+  grossPay: number;
+  paygWithheld: number;
+  superAccrued: number;
+  createdAt: string;
+}
+
+export interface PayrollDataset {
+  employees: EmployeeRecord[];
+  payRuns: PayRunRecord[];
+  payslips: PayslipRecord[];
+}
+
+export interface PayrollFeatureRecord {
+  employeeId: string;
+  payRunId: string;
+  periodStart: string;
+  periodEnd: string;
+  paymentDate: string;
+  grossPay: number;
+  paygWithheld: number;
+  superAccrued: number;
+  netPay: number;
+  payPeriodDays: number;
+  grossPerDay: number;
+}
+
+export interface NormalizationStats {
+  field: keyof PayrollFeatureRecord;
+  mean: number;
+  stdDev: number;
+  min: number;
+  max: number;
+}
+
+export interface NormalizedFeatureSet {
+  records: PayrollFeatureRecord[];
+  stats: NormalizationStats[];
+}
+
+export interface PipelineMetadata {
+  version: string;
+  generatedAt: string;
+  sourceDataset: string;
+  recordCount: number;
+  featureSchema: Array<{
+    name: keyof PayrollFeatureRecord;
+    type: 'string' | 'number';
+    description: string;
+  }>;
+  normalization: NormalizationStats[];
+}

--- a/packages/model-service/tsconfig.json
+++ b/packages/model-service/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "declaration": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "data/**/*.ts"
+  ],
+  "exclude": [
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the new @apgms/model-service workspace for reusable data preparation
- generate dataset manifests from the Prisma schema and export payroll data via CLI scripts
- create a payroll feature pipeline that emits normalized outputs with audit metadata

## Testing
- pnpm --filter @apgms/model-service build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ad1bbcb48327bd499d174f099f57)