### PR TITLE
feat: add ml inference service

### DIFF
--- a/services/ml-inference/Dockerfile
+++ b/services/ml-inference/Dockerfile
@@ -3,8 +3,10 @@ FROM node:20.18-alpine AS base
 WORKDIR /usr/src/app
 
 FROM base AS deps
-COPY package.json tsconfig.json pnpm-lock.yaml* ./
 COPY ../../pnpm-workspace.yaml ../../package.json ../../pnpm-lock.yaml /usr/src/
+COPY ../../packages /usr/src/packages
+COPY ../../shared /usr/src/shared
+COPY package.json tsconfig.json pnpm-lock.yaml* ./
 RUN corepack enable && corepack prepare pnpm@9.12.1 --activate && \
     pnpm install --frozen-lockfile --filter @apgms/ml-inference...
 


### PR DESCRIPTION
## Summary
- add a Fastify-based ML inference microservice that loads a packaged logistic model, publishes anomaly events, and exposes Prometheus metrics
- containerize the service and add local compose + Kubernetes manifests along with event bus subject documentation
- document operational guidance in a new runbook for the ML inference pipeline

## Testing
- pnpm --filter @apgms/ml-inference build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911abdf8b0c83278f5e2a040d251029)