### PR TITLE
feat: add inference service for model scoring

### DIFF
--- a/services/inference/src/nats/worker.ts
+++ b/services/inference/src/nats/worker.ts
@@ -86,6 +86,10 @@ export async function initInferenceWorker(app: FastifyInstance): Promise<void> {
       recordInferenceError("nats", app.inferenceEngine.version, "execution_error");
       observeInference("nats", app.inferenceEngine.version, "error", duration);
       app.log.error({ err: safeLogError(error) }, "inference_nats_failed");
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("inference_nats_failed");
     }
   });
 


### PR DESCRIPTION
## Summary
- add the @apgms/inference Fastify service that wraps the trained model behind a REST endpoint and JetStream worker
- define shared inference request/result types and document the integration contracts and metrics
- wire Prometheus instrumentation and node-based smoke tests to monitor the inference path

## Testing
- pnpm --filter @apgms/inference test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ad1edab083278fca57c761e869fe)