### PR TITLE
feat: add ml-core package and baseline feature pipelines

### DIFF
--- a/artifacts/notebooks/gradient_boosting_baseline.ipynb
+++ b/artifacts/notebooks/gradient_boosting_baseline.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Gradient Boosting Baseline\n",
+    "This notebook trains a gradient boosting classifier on synthetic ledger and payroll features\n",
+    "to validate the `ml_core` feature pipelines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import date\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.ensemble import GradientBoostingClassifier\n",
+    "from sklearn.metrics import precision_score, recall_score\n",
+    "\n",
+    "from ml_core.features import FeatureConfig\n",
+    "from ml_core.experiments.logging import log_experiment\n",
+    "\n",
+    "# Mock executor returns deterministic features for demonstration\n",
+    "class MockExecutor:\n",
+    "    def fetch_dataframe(self, query: str, *, params=None):\n",
+    "        if \"Posting\" in query:\n",
+    "            return pd.DataFrame({\n",
+    "                \"org_id\": [params[\"org_id\"]] * 6,\n",
+    "                \"occurred_date\": pd.date_range(end=params[\"as_of\"], periods=6),\n",
+    "                \"account_id\": [\"acct\"] * 6,\n",
+    "                \"net_amount_aud\": np.linspace(-500, 500, 6),\n",
+    "                \"posting_count\": [3, 4, 5, 3, 2, 1],\n",
+    "            })\n",
+    "        if \"PayRun\" in query:\n",
+    "            return pd.DataFrame({\n",
+    "                \"payment_date\": pd.date_range(end=params[\"as_of\"], periods=4),\n",
+    "                \"period_end\": pd.date_range(end=params[\"as_of\"], periods=4) - pd.Timedelta(days=1),\n",
+    "                \"payslip_count\": [10, 12, 9, 11],\n",
+    "                \"gross_pay_amount\": [55000, 53000, 54000, 52000],\n",
+    "            })\n",
+    "        return pd.DataFrame({\n",
+    "            \"status\": [\"OPEN\", \"CLOSED\"],\n",
+    "            \"opened_at\": pd.date_range(end=params[\"as_of\"], periods=2),\n",
+    "            \"resolved_at\": pd.date_range(end=params[\"as_of\"], periods=2),\n",
+    "            \"source\": [\"reconciliation\", \"operations\"],\n",
+    "        })\n",
+    "\n",
+    "executor = MockExecutor()\n",
+    "config = FeatureConfig(org_id=\"demo-org\", as_of_date=date.today())\n",
+    "\n",
+    "from ml_core.features.pipeline import build_training_set\n",
+    "features = build_training_set(executor, config)\n",
+    "\n",
+    "# Synthetic binary target\n",
+    "rng = np.random.default_rng(seed=42)\n",
+    "X = np.tile(features.drop(columns=[\"org_id\"]).to_numpy(), (50, 1))\n",
+    "y = rng.integers(0, 2, size=50)\n",
+    "\n",
+    "model = GradientBoostingClassifier(random_state=42)\n",
+    "model.fit(X, y)\n",
+    "preds = model.predict(X)\n",
+    "precision = precision_score(y, preds, zero_division=0)\n",
+    "recall = recall_score(y, preds, zero_division=0)\n",
+    "\n",
+    "log_experiment(\n",
+    "    \"gradient_boosting_baseline\",\n",
+    "    params={\"n_features\": X.shape[1]},\n",
+    "    metrics={\"precision\": float(precision), \"recall\": float(recall)},\n",
+    ")\n",
+    "\n",
+    "precision, recall\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/artifacts/notebooks/isolation_forest_baseline.ipynb
+++ b/artifacts/notebooks/isolation_forest_baseline.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Isolation Forest Baseline\n",
+    "The anomaly-detection baseline evaluates isolation forest using the same aggregated features\n",
+    "exported by `ml_core`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import date\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.ensemble import IsolationForest\n",
+    "from sklearn.metrics import precision_score, recall_score\n",
+    "\n",
+    "from ml_core.features import FeatureConfig\n",
+    "from ml_core.experiments.logging import log_experiment\n",
+    "from ml_core.features.pipeline import build_training_set\n",
+    "\n",
+    "class MockExecutor:\n",
+    "    def fetch_dataframe(self, query: str, *, params=None):\n",
+    "        if \"Posting\" in query:\n",
+    "            return pd.DataFrame({\n",
+    "                \"org_id\": [params[\"org_id\"]] * 3,\n",
+    "                \"occurred_date\": pd.date_range(end=params[\"as_of\"], periods=3),\n",
+    "                \"account_id\": [\"acct\"] * 3,\n",
+    "                \"net_amount_aud\": [1000, -250, 500],\n",
+    "                \"posting_count\": [5, 4, 3],\n",
+    "            })\n",
+    "        if \"PayRun\" in query:\n",
+    "            return pd.DataFrame({\n",
+    "                \"payment_date\": pd.date_range(end=params[\"as_of\"], periods=3),\n",
+    "                \"period_end\": pd.date_range(end=params[\"as_of\"], periods=3) - pd.Timedelta(days=2),\n",
+    "                \"payslip_count\": [9, 10, 11],\n",
+    "                \"gross_pay_amount\": [48000, 50000, 49500],\n",
+    "            })\n",
+    "        return pd.DataFrame({\n",
+    "            \"status\": [\"OPEN\"],\n",
+    "            \"opened_at\": pd.date_range(end=params[\"as_of\"], periods=1),\n",
+    "            \"resolved_at\": [pd.NaT],\n",
+    "            \"source\": [\"reconciliation\"],\n",
+    "        })\n",
+    "\n",
+    "executor = MockExecutor()\n",
+    "config = FeatureConfig(org_id=\"demo-org\", as_of_date=date.today())\n",
+    "features = build_training_set(executor, config).drop(columns=[\"org_id\"]).to_numpy()\n",
+    "\n",
+    "rng = np.random.default_rng(seed=123)\n",
+    "X = np.tile(features, (100, 1)) + rng.normal(scale=0.1, size=(100, features.shape[1]))\n",
+    "y = np.zeros(100, dtype=int)\n",
+    "y[rng.choice(100, size=10, replace=False)] = 1  # synthetic anomalies\n",
+    "\n",
+    "model = IsolationForest(random_state=123, contamination=0.1)\n",
+    "model.fit(X)\n",
+    "scores = model.predict(X)\n",
+    "preds = (scores == -1).astype(int)\n",
+    "precision = precision_score(y, preds, zero_division=0)\n",
+    "recall = recall_score(y, preds, zero_division=0)\n",
+    "\n",
+    "log_experiment(\n",
+    "    \"isolation_forest_baseline\",\n",
+    "    params={\"contamination\": 0.1},\n",
+    "    metrics={\"precision\": float(precision), \"recall\": float(recall)},\n",
+    ")\n",
+    "\n",
+    "precision, recall\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/ml/README.md
+++ b/docs/ml/README.md
@@ -1,0 +1,29 @@
+# Machine Learning Performance Gates
+
+This document captures the baseline evaluation criteria for ml-core models. Each gate is
+tuned to balance fraud prevention with cash-flow resilience for small businesses.
+
+## Fraud Alert Precision
+
+- **Target:** 0.92 precision @ 10% recall on out-of-sample fraud alerts.
+- **Rationale:** Operations can only triage a limited number of alerts per week; a
+  precision floor ensures analysts spend time on credible fraud risks.
+- **Measurement:** Evaluate on the hold-out alert dataset exported from the ledger
+  surveillance system. Precision is measured on the top decile of model scores.
+
+## Shortfall Detection Recall
+
+- **Target:** 0.85 recall @ 0.50 precision on payroll shortfall scenarios.
+- **Rationale:** Missing shortfall cases creates compliance exposure. We bias toward
+  higher recall while maintaining a workable review volume.
+- **Measurement:** Derived from scenario replays that compare required vs. secured
+  balances across BAS cycles. Recall is computed against confirmed shortfalls flagged by
+  reconciliation analysts.
+
+## Drift Monitoring
+
+- **Target:** No more than a 10% drop in either precision or recall over any rolling
+  30-day window.
+- **Rationale:** Ensures model updates or data drift are detected quickly.
+- **Measurement:** Weekly retraining jobs produce evaluation artifacts stored via the
+  experiment logging utilities in `ml_core.experiments.logging`.

--- a/packages/ml-core/README.md
+++ b/packages/ml-core/README.md
@@ -1,0 +1,25 @@
+# ml-core
+
+The `ml-core` package centralises machine-learning feature engineering and experiment
+tracking logic for APGMS. It is structured as a Poetry project so it can be installed as a
+standalone dependency in notebooks, services, or scheduled jobs that need access to
+feature pipelines or shared utilities.
+
+## Installation
+
+```bash
+poetry install
+```
+
+or, if you prefer `uv`:
+
+```bash
+uv sync
+```
+
+## Layout
+
+- `src/ml_core/features/`: Composable feature pipelines backed by production Prisma
+  queries.
+- `src/ml_core/experiments/`: Utilities that help notebooks track experiments without
+  requiring a full MLOps stack.

--- a/packages/ml-core/pyproject.toml
+++ b/packages/ml-core/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "ml-core"
+version = "0.1.0"
+description = "Core machine learning utilities and feature pipelines for APGMS"
+authors = ["APGMS Data Science Team <ml@apgms.example>"]
+packages = [{ include = "ml_core", from = "src" }]
+license = "MIT"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+numpy = "^2.1.3"
+pandas = "^2.2.3"
+scikit-learn = "^1.5.2"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.3"
+
+[build-system]
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/ml-core/src/ml_core/__init__.py
+++ b/packages/ml-core/src/ml_core/__init__.py
@@ -1,0 +1,5 @@
+"""Core machine learning utilities for APGMS."""
+
+from .features.pipeline import build_training_set
+
+__all__ = ["build_training_set"]

--- a/packages/ml-core/src/ml_core/experiments/__init__.py
+++ b/packages/ml-core/src/ml_core/experiments/__init__.py
@@ -1,0 +1,5 @@
+"""Experiment utilities exported by ml-core."""
+
+from .logging import DEFAULT_LOG_DIR, ExperimentRecord, log_experiment
+
+__all__ = ["DEFAULT_LOG_DIR", "ExperimentRecord", "log_experiment"]

--- a/packages/ml-core/src/ml_core/experiments/logging.py
+++ b/packages/ml-core/src/ml_core/experiments/logging.py
@@ -1,0 +1,51 @@
+"""Lightweight JSON logging for model experiments."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+DEFAULT_LOG_DIR = Path("artifacts/experiment_logs")
+
+
+@dataclass(slots=True)
+class ExperimentRecord:
+    name: str
+    created_at: str
+    params: Mapping[str, Any]
+    metrics: Mapping[str, float]
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def log_experiment(
+    name: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+    metrics: Mapping[str, float] | None = None,
+    directory: Path | None = None,
+) -> Path:
+    """Persist experiment metadata to a JSON artifact."""
+
+    directory = directory or DEFAULT_LOG_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+
+    record = ExperimentRecord(
+        name=name,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        params=params or {},
+        metrics=metrics or {},
+    )
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = directory / f"{timestamp}_{name.replace(' ', '_').lower()}.json"
+    path.write_text(record.to_json())
+    return path
+
+
+__all__ = ["log_experiment", "ExperimentRecord", "DEFAULT_LOG_DIR"]

--- a/packages/ml-core/src/ml_core/features/__init__.py
+++ b/packages/ml-core/src/ml_core/features/__init__.py
@@ -1,0 +1,14 @@
+"""Feature pipelines exposed by ml-core."""
+
+from .base import FeatureConfig, QueryExecutor
+from .discrepancy_metadata import discrepancy_metadata_features
+from .ledger_history import ledger_history_features
+from .payment_punctuality import payment_punctuality_features
+
+__all__ = [
+    "FeatureConfig",
+    "QueryExecutor",
+    "discrepancy_metadata_features",
+    "ledger_history_features",
+    "payment_punctuality_features",
+]

--- a/packages/ml-core/src/ml_core/features/base.py
+++ b/packages/ml-core/src/ml_core/features/base.py
@@ -1,0 +1,40 @@
+"""Shared interfaces for feature pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Protocol
+
+import pandas as pd
+
+
+class QueryExecutor(Protocol):
+    """Protocol for objects that can execute SQL against the production warehouse."""
+
+    def fetch_dataframe(self, query: str, *, params: dict | None = None) -> pd.DataFrame:
+        """Return the results of ``query`` as a :class:`pandas.DataFrame`.
+
+        Implementations are expected to honour the parameter style supported by the
+        backing driver (named parameters for ``asyncpg``/``psycopg`` for example).
+        """
+
+
+@dataclass(slots=True)
+class FeatureConfig:
+    """Standard configuration shared across feature builders."""
+
+    org_id: str
+    as_of_date: date
+    lookback_days: int = 180
+
+
+def _default_params(config: FeatureConfig) -> dict:
+    return {
+        "org_id": config.org_id,
+        "as_of": config.as_of_date,
+        "lookback_days": config.lookback_days,
+    }
+
+
+__all__ = ["QueryExecutor", "FeatureConfig", "_default_params"]

--- a/packages/ml-core/src/ml_core/features/discrepancy_metadata.py
+++ b/packages/ml-core/src/ml_core/features/discrepancy_metadata.py
@@ -1,0 +1,77 @@
+"""Discrepancy and alert metadata features."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import FeatureConfig, QueryExecutor, _default_params
+
+DISCREPANCY_QUERY = """
+SELECT
+    'reconciliation'::text AS source,
+    ra."kind"             AS category,
+    ra."status"           AS status,
+    ra."openedAt"         AS opened_at,
+    ra."resolvedAt"       AS resolved_at
+FROM "ReconciliationAlert" AS ra
+WHERE ra."orgId" = %(org_id)s
+  AND ra."openedAt" BETWEEN (%(as_of)s - INTERVAL '%(lookback_days)s days') AND %(as_of)s
+UNION ALL
+SELECT
+    'operations'::text AS source,
+    a."type"          AS category,
+    CASE WHEN a."resolvedAt" IS NULL THEN 'OPEN' ELSE 'CLOSED' END AS status,
+    a."createdAt"     AS opened_at,
+    a."resolvedAt"    AS resolved_at
+FROM "Alert" AS a
+WHERE a."orgId" = %(org_id)s
+  AND a."createdAt" BETWEEN (%(as_of)s - INTERVAL '%(lookback_days)s days') AND %(as_of)s;
+"""
+
+
+def discrepancy_metadata_features(executor: QueryExecutor, config: FeatureConfig) -> pd.DataFrame:
+    """Aggregate reconciliation and alert signals."""
+
+    frame = executor.fetch_dataframe(DISCREPANCY_QUERY, params=_default_params(config))
+    if frame.empty:
+        return pd.DataFrame(
+            [
+                {
+                    "org_id": config.org_id,
+                    "open_discrepancy_count": 0.0,
+                    "avg_resolution_hours": 0.0,
+                    "reconciliation_alert_ratio": 0.0,
+                }
+            ]
+        )
+
+    frame["opened_at"] = pd.to_datetime(frame["opened_at"])
+    frame["resolved_at"] = pd.to_datetime(frame["resolved_at"])
+
+    open_count = (frame["status"].str.upper() == "OPEN").sum()
+    closed = frame[frame["status"].str.upper() != "OPEN"].copy()
+    if not closed.empty:
+        closed["resolution_hours"] = (
+            (closed["resolved_at"] - closed["opened_at"]).dt.total_seconds() / 3600.0
+        )
+        avg_resolution_hours = float(closed["resolution_hours"].mean())
+    else:
+        avg_resolution_hours = 0.0
+
+    reconciliation_ratio = float(
+        (frame["source"] == "reconciliation").sum() / len(frame)
+    ) if len(frame) else 0.0
+
+    return pd.DataFrame(
+        [
+            {
+                "org_id": config.org_id,
+                "open_discrepancy_count": float(open_count),
+                "avg_resolution_hours": avg_resolution_hours,
+                "reconciliation_alert_ratio": reconciliation_ratio,
+            }
+        ]
+    )
+
+
+__all__ = ["discrepancy_metadata_features", "DISCREPANCY_QUERY"]

--- a/packages/ml-core/src/ml_core/features/ledger_history.py
+++ b/packages/ml-core/src/ml_core/features/ledger_history.py
@@ -1,0 +1,88 @@
+"""Ledger history feature generation."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pandas as pd
+
+from .base import FeatureConfig, QueryExecutor, _default_params
+
+LEDGER_HISTORY_QUERY = """
+WITH recent_postings AS (
+    SELECT
+        j."orgId"          AS org_id,
+        DATE(j."occurredAt") AS occurred_date,
+        p."accountId"      AS account_id,
+        SUM(p."amountCents") / 100.0 AS net_amount_aud,
+        COUNT(*)            AS posting_count
+    FROM "Posting" AS p
+    INNER JOIN "Journal" AS j ON j."id" = p."journalId"
+    WHERE j."orgId" = %(org_id)s
+      AND j."occurredAt" BETWEEN (%(as_of)s - INTERVAL '%(lookback_days)s days') AND %(as_of)s
+    GROUP BY 1, 2, 3
+)
+SELECT
+    org_id,
+    occurred_date,
+    account_id,
+    net_amount_aud,
+    posting_count
+FROM recent_postings
+ORDER BY occurred_date DESC;
+"""
+
+
+WINDOWS = (30, 90, 180)
+
+
+def ledger_history_features(executor: QueryExecutor, config: FeatureConfig) -> pd.DataFrame:
+    """Aggregate ledger movement statistics for the configured organisation."""
+
+    frame = executor.fetch_dataframe(LEDGER_HISTORY_QUERY, params=_default_params(config))
+    if frame.empty:
+        return _empty_frame(config.org_id)
+
+    frame["occurred_date"] = pd.to_datetime(frame["occurred_date"])
+    frame["abs_amount_aud"] = frame["net_amount_aud"].abs()
+
+    feature_data: dict[str, float] = {"org_id": config.org_id}
+    for window in WINDOWS:
+        summary = _summarise_window(frame, config, window)
+        feature_data.update(summary)
+
+    return pd.DataFrame([feature_data])
+
+
+def _summarise_window(frame: pd.DataFrame, config: FeatureConfig, window: int) -> dict[str, float]:
+    cutoff = pd.Timestamp(config.as_of_date - timedelta(days=window))
+    window_frame = frame[frame["occurred_date"] >= cutoff]
+
+    if window_frame.empty:
+        return {
+            f"ledger_net_amount_{window}d": 0.0,
+            f"ledger_abs_amount_{window}d": 0.0,
+            f"ledger_posting_count_{window}d": 0.0,
+        }
+
+    return {
+        f"ledger_net_amount_{window}d": window_frame["net_amount_aud"].sum(),
+        f"ledger_abs_amount_{window}d": window_frame["abs_amount_aud"].sum(),
+        f"ledger_posting_count_{window}d": float(window_frame["posting_count"].sum()),
+    }
+
+
+def _empty_frame(org_id: str) -> pd.DataFrame:
+    payload = {"org_id": org_id}
+    for window in WINDOWS:
+        payload.update(
+            {
+                f"ledger_net_amount_{window}d": 0.0,
+                f"ledger_abs_amount_{window}d": 0.0,
+                f"ledger_posting_count_{window}d": 0.0,
+            }
+        )
+    return pd.DataFrame([payload])
+
+
+__all__ = ["ledger_history_features", "LEDGER_HISTORY_QUERY"]

--- a/packages/ml-core/src/ml_core/features/payment_punctuality.py
+++ b/packages/ml-core/src/ml_core/features/payment_punctuality.py
@@ -1,0 +1,66 @@
+"""Payroll punctuality features."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import FeatureConfig, QueryExecutor, _default_params
+
+PAYMENT_PUNCTUALITY_QUERY = """
+SELECT
+    pr."id"            AS pay_run_id,
+    pr."orgId"         AS org_id,
+    pr."periodStart"   AS period_start,
+    pr."periodEnd"     AS period_end,
+    pr."paymentDate"   AS payment_date,
+    pr."status"        AS status,
+    COUNT(ps."id")     AS payslip_count,
+    COALESCE(SUM(ps."grossPay"), 0)::float AS gross_pay_amount
+FROM "PayRun" AS pr
+LEFT JOIN "Payslip" AS ps ON ps."payRunId" = pr."id"
+WHERE pr."orgId" = %(org_id)s
+  AND pr."paymentDate" BETWEEN (%(as_of)s - INTERVAL '%(lookback_days)s days') AND %(as_of)s
+GROUP BY 1, 2, 3, 4, 5, 6
+ORDER BY pr."paymentDate" DESC;
+"""
+
+
+def payment_punctuality_features(executor: QueryExecutor, config: FeatureConfig) -> pd.DataFrame:
+    """Return aggregate punctuality metrics for payroll runs."""
+
+    frame = executor.fetch_dataframe(PAYMENT_PUNCTUALITY_QUERY, params=_default_params(config))
+    if frame.empty:
+        return pd.DataFrame(
+            [
+                {
+                    "org_id": config.org_id,
+                    "avg_payment_lag_days": 0.0,
+                    "late_payment_ratio": 0.0,
+                    "payslip_volume": 0.0,
+                    "gross_pay_total": 0.0,
+                }
+            ]
+        )
+
+    frame["payment_date"] = pd.to_datetime(frame["payment_date"])
+    frame["period_end"] = pd.to_datetime(frame["period_end"])
+    frame["lag_days"] = (frame["payment_date"] - frame["period_end"]).dt.days
+
+    late_mask = frame["lag_days"] > 0
+    total_runs = len(frame)
+    late_runs = late_mask.sum()
+
+    return pd.DataFrame(
+        [
+            {
+                "org_id": config.org_id,
+                "avg_payment_lag_days": float(frame["lag_days"].mean()),
+                "late_payment_ratio": float(late_runs / total_runs) if total_runs else 0.0,
+                "payslip_volume": float(frame["payslip_count"].sum()),
+                "gross_pay_total": float(frame["gross_pay_amount"].sum()),
+            }
+        ]
+    )
+
+
+__all__ = ["payment_punctuality_features", "PAYMENT_PUNCTUALITY_QUERY"]

--- a/packages/ml-core/src/ml_core/features/pipeline.py
+++ b/packages/ml-core/src/ml_core/features/pipeline.py
@@ -1,0 +1,34 @@
+"""High level orchestration for feature pipelines."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import FeatureConfig, QueryExecutor
+from .discrepancy_metadata import discrepancy_metadata_features
+from .ledger_history import ledger_history_features
+from .payment_punctuality import payment_punctuality_features
+
+
+def build_training_set(executor: QueryExecutor, config: FeatureConfig) -> pd.DataFrame:
+    """Return a joined training set for the provided organisation.
+
+    The training set currently aggregates ledger statistics, payroll punctuality metrics,
+    and reconciliation alert metadata into a single row keyed by ``org_id``.
+    """
+
+    frames = [
+        ledger_history_features(executor, config),
+        payment_punctuality_features(executor, config),
+        discrepancy_metadata_features(executor, config),
+    ]
+
+    dataset = frames[0]
+    for frame in frames[1:]:
+        dataset = dataset.merge(frame, on="org_id", how="outer")
+
+    dataset = dataset.fillna(0)
+    return dataset
+
+
+__all__ = ["build_training_set"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas==2.2.3
 numpy==2.1.3
+scikit-learn==1.5.2
 pytest==8.3.3


### PR DESCRIPTION
## Summary
- scaffold a standalone ml-core Poetry project with core ML dependencies and JSON experiment logging utilities
- implement ledger, payroll, and discrepancy feature pipelines backed by Prisma-aligned SQL queries
- add baseline gradient boosting and isolation forest notebooks plus document performance gates for fraud and shortfall models

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b5a0df1083279d4fb1601dfd608c)