### PR TITLE
Add ML service observability and governance workflows

### DIFF
--- a/shared/prisma/migrations/20251104103000_model_feedback/migration.sql
+++ b/shared/prisma/migrations/20251104103000_model_feedback/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "FeedbackLabel" AS ENUM ('FALSE_POSITIVE', 'FALSE_NEGATIVE');
+
+-- CreateEnum
+CREATE TYPE "FeedbackSource" AS ENUM ('REGULATOR', 'FINANCE');
+
+-- CreateTable
+CREATE TABLE "ModelFeedback" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "modelId" TEXT NOT NULL,
+    "modelVersion" TEXT NOT NULL,
+    "predictionId" TEXT NOT NULL,
+    "label" "FeedbackLabel" NOT NULL,
+    "source" "FeedbackSource" NOT NULL,
+    "submittedBy" TEXT NOT NULL,
+    "submittedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "notes" TEXT,
+    "metadata" JSONB,
+
+    CONSTRAINT "ModelFeedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ModelFeedback_modelId_modelVersion_idx" ON "ModelFeedback"("modelId", "modelVersion");
+
+-- CreateIndex
+CREATE INDEX "ModelFeedback_predictionId_idx" ON "ModelFeedback"("predictionId");
+
+-- CreateIndex
+CREATE INDEX "ModelFeedback_label_source_idx" ON "ModelFeedback"("label", "source");


### PR DESCRIPTION
## Summary
- add the @apgms/ml-service Fastify package with Prometheus instrumentation for inference latency, error budgets, drift, and feedback counters
- expose inference and feedback endpoints backed by Prisma, including the new ModelFeedback table for regulator labels
- check model provenance, bias, and artifact checksums through governance scripts, CI workflow, and updated ML operations runbook

## Testing
- pnpm --filter @apgms/ml-service run build
- pnpm --filter @apgms/ml-service run governance:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bc1b6de08327a93ee7e88f3a5594)