### PR TITLE
Add ML risk service integration across stack

### DIFF
--- a/services/api-gateway/src/types/fastify.d.ts
+++ b/services/api-gateway/src/types/fastify.d.ts
@@ -4,6 +4,34 @@ import type { MlServiceClient } from "../clients/ml-service.js";
 
 declare module "fastify" {
   interface FastifyInstance {
+    config: {
+      taxEngineUrl?: string;
+      [k: string]: unknown;
+    };
+    metrics?: {
+      recordSecurityEvent?: (code: string) => void;
+      httpRequestTotal?: any;
+      httpRequestDuration?: {
+        startTimer: (
+          labels?: Record<string, string>,
+        ) => (labels?: Record<string, string>) => void;
+      };
+    };
+    isDraining?: () => boolean;
+    setDraining?: (v: boolean) => void;
+    providers?: {
+      redis?: { ping: () => Promise<string> } | null;
+      nats?: { flush: () => Promise<void> } | null;
+    };
     mlClient: MlServiceClient;
+  }
+
+  interface FastifyRequest {
+    user?: {
+      sub: string;
+      orgId: string;
+      role: string;
+      mfaEnabled: boolean;
+    };
   }
 }


### PR DESCRIPTION
## Summary
- add a FastAPI ML risk microservice with Prometheus metrics, serialized models, and pytest coverage
- integrate the ML service client into the API gateway for readiness probes, bank line gating, and new risk routes
- surface ML risk insights in the web dashboard with hooks, styling, and Vitest coverage

## Testing
- pytest services/ml-service/tests/test_risk.py
- pnpm --filter apgms-webapp exec vitest run src/pages/Home.test.tsx
- pnpm --filter @apgms/api-gateway exec tsx ./test/run.ts *(fails: legacy admin specs expect missing routes)*
- pnpm --filter @apgms/api-gateway exec tsx ./test/bank-lines.risk.spec.ts *(fails: tsx cannot resolve @apgms/shared package)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bc1921908327a2e3f2ec73a541f9)