### PR TITLE
Add ML service feedback APIs and governance workflows

### DIFF
--- a/shared/prisma/migrations/20251104103000_model_feedback/migration.sql
+++ b/shared/prisma/migrations/20251104103000_model_feedback/migration.sql
@@ -1,0 +1,26 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+DO $$
+BEGIN
+  CREATE TYPE "FeedbackRole" AS ENUM ('FINANCE', 'REGULATOR');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "ModelFeedback" (
+  "id" TEXT NOT NULL DEFAULT gen_random_uuid(),
+  "predictionId" TEXT NOT NULL,
+  "modelVersion" TEXT NOT NULL,
+  "label" TEXT NOT NULL,
+  "submittedBy" TEXT NOT NULL,
+  "submittedRole" "FeedbackRole" NOT NULL,
+  "confidence" DOUBLE PRECISION,
+  "notes" TEXT,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ModelFeedback_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "ModelFeedback_predictionId_modelVersion_idx"
+  ON "ModelFeedback" ("predictionId", "modelVersion");
+CREATE INDEX IF NOT EXISTS "ModelFeedback_submittedRole_createdAt_idx"
+  ON "ModelFeedback" ("submittedRole", "createdAt");


### PR DESCRIPTION
## Summary
- introduce a new ml-service fastify app with inference telemetry endpoints, human feedback capture, and Prometheus metrics
- persist human-in-the-loop labels through a ModelFeedback Prisma model and surface governance dashboards for latency, error budgets, and drift
- document retraining and rollback controls while enforcing artifact integrity, bias, and reproducibility checks in CI

## Testing
- pnpm --filter @apgms/ml-service run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ccbfa5148327b6a9b3bfa69a091a)