### PR TITLE
feat: add ml-core package with baseline modeling pipelines

### DIFF
--- a/packages/ml-core/src/ml_core/pipelines/baseline.py
+++ b/packages/ml-core/src/ml_core/pipelines/baseline.py
@@ -132,7 +132,7 @@ def train_fraud_anomaly_detection(config: BaselineTrainingConfig) -> BaselineRes
 
     with start_run(config.experiment_name, config.run_name, tags={"task": "fraud_detection"}) as active_run:
         pipeline.fit(feature_frame)
-        scores = pipeline[-1].score_samples(feature_frame)
+        scores = pipeline.score_samples(feature_frame)
         anomaly_threshold = np.percentile(scores, 5)
         predicted_labels = (scores < anomaly_threshold).astype(int)
 


### PR DESCRIPTION
## Summary
- scaffold `packages/ml-core` with Poetry/uv configuration, feature builders, MLflow utilities, and baseline training CLI
- add dataset documentation and model standards covering acceptance criteria, fairness metrics, and audit guidelines
- document artifact outputs and register the new package in the workspace configuration

## Testing
- not run (requires ML dependencies not installed in CI image)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120608274c83279ecc39f831371f0e)