### PR TITLE
Add integration connectors and automate ATO submissions

### DIFF
--- a/services/ato-client/src/stp.ts
+++ b/services/ato-client/src/stp.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "./http.js";
-import { OAuthSession, type OAuthConfig } from "./oauth.ts";
+import { OAuthSession, type OAuthConfig } from "./oauth.js";
 
 export type StpSubmissionEmployee = {
   identifier: string;


### PR DESCRIPTION
## Summary
- replace the connectors stub with OAuth-enabled banking, payroll, and POS clients including webhook signature verification helpers
- extend the ledger API and Prisma schema to enforce deposit-only designated accounts with reconciliation records and hashed audit trails
- add an @apgms/ato-client package plus worker jobs to submit STP/BAS filings and document integration runbooks for onboarding, rotation, and incident response

## Testing
- pnpm --filter @apgms/api-gateway build *(fails: existing project type resolution issues for @apgms/shared and prisma stubs)*
- pnpm --filter @apgms/worker test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120604cf988327b9869d4db7d34840)