### PR TITLE
Add compliance telemetry pipeline and data governance policy

### DIFF
--- a/services/api-gateway/src/lib/auth.js
+++ b/services/api-gateway/src/lib/auth.js
@@ -137,6 +137,15 @@ export async function authenticateRequest(app, request, reply, roles) {
     try {
         const principal = await verifyRequest(request, reply);
         requireRole(principal, roles);
+        request.principal = principal;
+        request.user = {
+            sub: principal.id,
+            orgId: principal.orgId,
+            role: principal.roles[0] ?? principal.roles[principal.roles.length - 1] ?? "analyst",
+            roles: principal.roles,
+            token: principal.token,
+            mfaEnabled: false,
+        };
         metrics?.recordSecurityEvent("auth.success");
         return principal;
     }

--- a/services/api-gateway/src/lib/auth.ts
+++ b/services/api-gateway/src/lib/auth.ts
@@ -204,6 +204,26 @@ export async function authenticateRequest(
   try {
     const principal = await verifyRequest(request, reply);
     requireRole(principal, roles);
+    const scopedRequest = request as FastifyRequest & {
+      principal?: Principal;
+      user?: {
+        sub: string;
+        orgId: string;
+        role: string;
+        roles?: Role[];
+        token?: string;
+        mfaEnabled?: boolean;
+      };
+    };
+    scopedRequest.principal = principal;
+    scopedRequest.user = {
+      sub: principal.id,
+      orgId: principal.orgId,
+      role: principal.roles[0] ?? principal.roles[principal.roles.length - 1] ?? "analyst",
+      roles: principal.roles,
+      token: principal.token,
+      mfaEnabled: false,
+    };
     metrics?.recordSecurityEvent("auth.success");
     return principal;
   } catch (error) {

--- a/services/api-gateway/src/types/fastify.d.ts
+++ b/services/api-gateway/src/types/fastify.d.ts
@@ -36,6 +36,14 @@ declare module "fastify" {
       orgId: string;
       role: string;
       mfaEnabled: boolean;
+      roles?: string[];
+      token?: string;
+    };
+    principal?: {
+      id: string;
+      orgId: string;
+      roles: string[];
+      token: string;
     };
     publishDomainEvent?: (event: {
       subject: string;


### PR DESCRIPTION
## Summary
- add discrepancy, fraud alert, remediation, and payment plan models to Prisma and ship a matching SQL migration
- emit structured NATS events from new ledger, payments, and compliance handlers via a dedicated Fastify plugin
- build a compliance ingestion worker that persists events, derives KPIs/training datasets, and document governance policies

## Testing
- `pnpm --filter @apgms/api-gateway build` *(fails: repository already contains unresolved TypeScript dependencies such as @apgms/shared and Prisma types)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120605d32483278341585c51dcf992)