### PR TITLE
feat(webapp): add admin prototype router behind feature flag

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -14,6 +14,14 @@ import RegulatorLayout from "./RegulatorLayout";
 import RegulatorOverviewPage from "./RegulatorOverviewPage";
 import RegulatorEvidencePage from "./RegulatorEvidencePage";
 import RegulatorMonitoringPage from "./RegulatorMonitoringPage";
+import { appConfig } from "./config";
+import {
+  AdminPrototypeGuard,
+  AdminPrototypeLayout,
+  OverviewPage as AdminPrototypeOverviewPage,
+  OnboardingFlowPage,
+  RiskReviewFlowPage,
+} from "./admin-prototype";
 
 export default function App() {
   return (
@@ -36,6 +44,20 @@ export default function App() {
           <Route path="/compliance" element={<CompliancePage />} />
           <Route path="/security" element={<SecurityPage />} />
         </Route>
+        {appConfig.featureFlags.adminPrototype && (
+          <Route
+            path="/admin-prototype"
+            element={
+              <AdminPrototypeGuard>
+                <AdminPrototypeLayout />
+              </AdminPrototypeGuard>
+            }
+          >
+            <Route index element={<AdminPrototypeOverviewPage />} />
+            <Route path="onboarding" element={<OnboardingFlowPage />} />
+            <Route path="risk-review" element={<RiskReviewFlowPage />} />
+          </Route>
+        )}
         {/* catch-all */}
         <Route
           path="*"

--- a/webapp/src/admin-prototype/AdminPrototypeGuard.tsx
+++ b/webapp/src/admin-prototype/AdminPrototypeGuard.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { getSessionUser, getToken } from "../auth";
+import { appConfig } from "../config";
+
+const ADMIN_ROLES = new Set(["admin", "superadmin", "root", "platform-admin"]);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function AdminPrototypeGuard({ children }: Props) {
+  const location = useLocation();
+  const token = getToken();
+  const user = getSessionUser();
+
+  if (!appConfig.featureFlags.adminPrototype) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (!token || !user) {
+    return (
+      <Navigate
+        to="/"
+        replace
+        state={{ from: location.pathname }}
+      />
+    );
+  }
+
+  const normalizedRole = user.role?.toLowerCase() ?? "";
+
+  if (!ADMIN_ROLES.has(normalizedRole)) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/webapp/src/admin-prototype/AdminPrototypeLayout.tsx
+++ b/webapp/src/admin-prototype/AdminPrototypeLayout.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { NavLink, Outlet } from "react-router-dom";
+import { getSessionUser } from "../auth";
+
+const navItems: Array<{ to: string; label: string; description: string }> = [
+  {
+    to: ".",
+    label: "Overview",
+    description: "Prototype scope & validation checkpoints",
+  },
+  {
+    to: "onboarding",
+    label: "Onboarding flow",
+    description: "Simulated customer vetting + cash control",
+  },
+  {
+    to: "risk-review",
+    label: "Risk review",
+    description: "Live alerts feed mapped to regulator questions",
+  },
+];
+
+export default function AdminPrototypeLayout() {
+  const user = getSessionUser();
+
+  return (
+    <div style={layoutStyle}>
+      <aside style={sidebarStyle}>
+        <header style={sidebarHeaderStyle}>
+          <span style={prototypeBadgeStyle}>Prototype</span>
+          <h1 style={sidebarTitleStyle}>ATO admin walkthrough</h1>
+          <p style={sidebarSubtitleStyle}>
+            Internal only. Mirrors the APGMS production workflows with
+            anonymised ledger data.
+          </p>
+          {user && (
+            <p style={sidebarUserStyle}>
+              Signed in as <strong>{user.id}</strong>
+            </p>
+          )}
+        </header>
+        <nav style={navStyle}>
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.to === "."}
+              style={({ isActive }) => ({
+                padding: "12px 16px",
+                borderRadius: "10px",
+                display: "grid",
+                gap: "4px",
+                textDecoration: "none",
+                color: isActive ? "#0b5fff" : "#1f2937",
+                backgroundColor: isActive ? "rgba(11, 95, 255, 0.08)" : "transparent",
+                boxShadow: isActive ? "0 0 0 1px rgba(11, 95, 255, 0.25)" : "none",
+                transition: "background 0.2s ease",
+              })}
+            >
+              <span style={{ fontWeight: 600 }}>{item.label}</span>
+              <span style={{ fontSize: "13px", color: "#4b5563" }}>
+                {item.description}
+              </span>
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <main style={mainStyle}>
+        <div style={contentWrapperStyle}>
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+const layoutStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "340px 1fr",
+  minHeight: "100vh",
+  fontFamily: "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  backgroundColor: "#f8fafc",
+};
+
+const sidebarStyle: React.CSSProperties = {
+  padding: "32px 28px",
+  borderRight: "1px solid #e2e8f0",
+  background: "linear-gradient(180deg, #ffffff 0%, #f1f5f9 100%)",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const sidebarHeaderStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "12px",
+  marginBottom: "32px",
+};
+
+const prototypeBadgeStyle: React.CSSProperties = {
+  alignSelf: "flex-start",
+  padding: "4px 8px",
+  borderRadius: "999px",
+  backgroundColor: "#0b5fff",
+  color: "white",
+  fontSize: "12px",
+  fontWeight: 600,
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+};
+
+const sidebarTitleStyle: React.CSSProperties = {
+  fontSize: "22px",
+  margin: 0,
+};
+
+const sidebarSubtitleStyle: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#475569",
+  margin: 0,
+  lineHeight: 1.4,
+};
+
+const sidebarUserStyle: React.CSSProperties = {
+  fontSize: "13px",
+  color: "#1f2937",
+  margin: 0,
+};
+
+const navStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "12px",
+};
+
+const mainStyle: React.CSSProperties = {
+  padding: "40px 48px",
+  overflowY: "auto",
+};
+
+const contentWrapperStyle: React.CSSProperties = {
+  maxWidth: "960px",
+  margin: "0 auto",
+  display: "grid",
+  gap: "32px",
+};

--- a/webapp/src/admin-prototype/index.ts
+++ b/webapp/src/admin-prototype/index.ts
@@ -1,0 +1,5 @@
+export { default as AdminPrototypeGuard } from "./AdminPrototypeGuard";
+export { default as AdminPrototypeLayout } from "./AdminPrototypeLayout";
+export { default as OverviewPage } from "./pages/OverviewPage";
+export { default as OnboardingFlowPage } from "./pages/OnboardingFlowPage";
+export { default as RiskReviewFlowPage } from "./pages/RiskReviewFlowPage";

--- a/webapp/src/admin-prototype/pages/OnboardingFlowPage.tsx
+++ b/webapp/src/admin-prototype/pages/OnboardingFlowPage.tsx
@@ -1,0 +1,199 @@
+import React, { useMemo } from "react";
+
+const mockApplications = [
+  {
+    id: "org_sydney_001",
+    legalName: "Sydney Freight Holdings",
+    abn: "12 345 678 901",
+    payrollProvider: "Employment Hero",
+    lastPayRun: "2025-02-14",
+    captureStatus: "Funds secured",
+  },
+  {
+    id: "org_melbourne_204",
+    legalName: "Melbourne Creative Studio",
+    abn: "98 765 432 109",
+    payrollProvider: "KeyPay",
+    lastPayRun: "2025-02-12",
+    captureStatus: "Pending sweep",
+  },
+];
+
+const onboardingSteps = [
+  {
+    title: "1. Intake & entity verification",
+    detail:
+      "We ingest the application payload (ABN, director IDs, trust deed) and resolve it against the Australian Business Register.",
+  },
+  {
+    title: "2. Bank mandate",
+    detail:
+      "The customer authorises APGMS to hold PAYGW/GST in segregated accounts. Mandate approval triggers a capture rule in the ledger service.",
+  },
+  {
+    title: "3. Payroll feed activation",
+    detail:
+      "We fetch the latest payroll run to pre-calculate the withholding amount and create a sweep to the protected account.",
+  },
+];
+
+export default function OnboardingFlowPage() {
+  const gridRows = useMemo(() => mockApplications, []);
+
+  return (
+    <div style={{ display: "grid", gap: "32px" }}>
+      <header style={headerStyle}>
+        <div>
+          <h2 style={pageTitleStyle}>Customer onboarding walkthrough</h2>
+          <p style={pageSubtitleStyle}>
+            Demo the compliance controls that run before a business can lodge BAS via
+            APGMS. All records below are mock identifiers wired into the dev API so we
+            can talk through the real payloads.
+          </p>
+        </div>
+        <span style={badgeStyle}>Mock data</span>
+      </header>
+
+      <section style={stepsGridStyle}>
+        {onboardingSteps.map((step) => (
+          <div key={step.title} style={stepCardStyle}>
+            <h3 style={stepTitleStyle}>{step.title}</h3>
+            <p style={stepDetailStyle}>{step.detail}</p>
+          </div>
+        ))}
+      </section>
+
+      <section style={tableWrapperStyle}>
+        <h3 style={tableTitleStyle}>Applications staged for demo</h3>
+        <div style={tableStyle}>
+          <div style={{ ...tableRowStyle, fontWeight: 600, color: "#1f2937" }}>
+            <span>Org ID</span>
+            <span>Legal name</span>
+            <span>ABN</span>
+            <span>Payroll provider</span>
+            <span>Last pay run</span>
+            <span>Capture status</span>
+          </div>
+          {gridRows.map((row) => (
+            <div key={row.id} style={tableRowStyle}>
+              <span style={monoStyle}>{row.id}</span>
+              <span>{row.legalName}</span>
+              <span style={monoStyle}>{row.abn}</span>
+              <span>{row.payrollProvider}</span>
+              <span>{row.lastPayRun}</span>
+              <span style={{ fontWeight: 600 }}>{row.captureStatus}</span>
+            </div>
+          ))}
+        </div>
+        <p style={tableFooterStyle}>
+          Use these identifiers to jump into the ledger service when regulators ask how we
+          ringfence PAYGW before BAS submission.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: "16px",
+  backgroundColor: "#ffffff",
+  padding: "24px 28px",
+  borderRadius: "16px",
+  boxShadow: "0 24px 48px rgba(15, 23, 42, 0.07)",
+};
+
+const pageTitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "22px",
+};
+
+const pageSubtitleStyle: React.CSSProperties = {
+  margin: "8px 0 0",
+  fontSize: "15px",
+  color: "#4b5563",
+  lineHeight: 1.5,
+};
+
+const badgeStyle: React.CSSProperties = {
+  alignSelf: "center",
+  backgroundColor: "#0b5fff",
+  color: "white",
+  fontSize: "12px",
+  fontWeight: 600,
+  padding: "6px 12px",
+  borderRadius: "999px",
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+};
+
+const stepsGridStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "16px",
+  gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+};
+
+const stepCardStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  padding: "20px",
+  borderRadius: "14px",
+  boxShadow: "0 16px 32px rgba(15, 23, 42, 0.05)",
+  display: "grid",
+  gap: "8px",
+};
+
+const stepTitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "16px",
+};
+
+const stepDetailStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "14px",
+  color: "#4b5563",
+  lineHeight: 1.45,
+};
+
+const tableWrapperStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  padding: "24px",
+  borderRadius: "16px",
+  boxShadow: "0 20px 40px rgba(15, 23, 42, 0.06)",
+  display: "grid",
+  gap: "16px",
+};
+
+const tableTitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "18px",
+};
+
+const tableStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "12px",
+};
+
+const tableRowStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+  gap: "12px",
+  alignItems: "center",
+  fontSize: "14px",
+  color: "#1f2937",
+  padding: "12px 16px",
+  borderRadius: "12px",
+  backgroundColor: "#f8fafc",
+};
+
+const monoStyle: React.CSSProperties = {
+  fontFamily: "'IBM Plex Mono', SFMono-Regular, ui-monospace, monospace",
+  fontSize: "13px",
+};
+
+const tableFooterStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "13px",
+  color: "#475569",
+};

--- a/webapp/src/admin-prototype/pages/OverviewPage.tsx
+++ b/webapp/src/admin-prototype/pages/OverviewPage.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { getSessionUser } from "../../auth";
+
+export default function OverviewPage() {
+  const user = getSessionUser();
+
+  return (
+    <div style={{ display: "grid", gap: "24px" }}>
+      <section style={introCardStyle}>
+        <div>
+          <h2 style={sectionTitleStyle}>Why this prototype exists</h2>
+          <p style={bodyTextStyle}>
+            The regulator walkthrough condenses the core APGMS workflows — onboarding,
+            ledger capture, and risk review — into a guided script. It is powered by the
+            same API services that back the production console, but swaps in synthetic
+            organisation identifiers so we can demo end-to-end without touching live
+            taxpayer records.
+          </p>
+        </div>
+        <ul style={bulletListStyle}>
+          <li>
+            <strong>Admin only:</strong> requires an admin role and the
+            <code style={codeStyle}> VITE_ENABLE_ADMIN_PROTOTYPE </code> flag.
+          </li>
+          <li>
+            <strong>Read-only:</strong> write operations are mocked and never call the
+            production ledger.
+          </li>
+          <li>
+            <strong>Scripted checkpoints:</strong> each page highlights the evidence we
+            surface when demonstrating controls to the ATO.
+          </li>
+        </ul>
+      </section>
+
+      <section style={twoColumnStyle}>
+        <div style={cardStyle}>
+          <h3 style={cardTitleStyle}>Suggested flow</h3>
+          <ol style={orderedListStyle}>
+            <li>Start with the onboarding walkthrough to show KYC & banking controls.</li>
+            <li>
+              Jump to the risk review to map our live alerts directly to regulator
+              questions.
+            </li>
+            <li>
+              Close by returning to the production dashboard to show parity between the
+              prototype and the deployed surface.
+            </li>
+          </ol>
+        </div>
+        <div style={cardStyle}>
+          <h3 style={cardTitleStyle}>Session context</h3>
+          <dl style={definitionListStyle}>
+            <div>
+              <dt>Environment flag</dt>
+              <dd>{import.meta.env.VITE_ENABLE_ADMIN_PROTOTYPE ? "Enabled" : "Disabled"}</dd>
+            </div>
+            <div>
+              <dt>Signed in user</dt>
+              <dd>{user?.id ?? "Unknown"}</dd>
+            </div>
+            <div>
+              <dt>Role</dt>
+              <dd>{user?.role ?? "Unknown"}</dd>
+            </div>
+          </dl>
+          <p style={bodyTextStyle}>
+            Toggle the feature flag per environment so that the prototype is only visible
+            in regulated dry-run sessions.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const introCardStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  padding: "32px",
+  borderRadius: "16px",
+  boxShadow: "0px 30px 60px rgba(15, 23, 42, 0.08)",
+  display: "grid",
+  gap: "24px",
+};
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: "24px",
+  margin: 0,
+};
+
+const bodyTextStyle: React.CSSProperties = {
+  fontSize: "15px",
+  color: "#1f2937",
+  lineHeight: 1.5,
+};
+
+const bulletListStyle: React.CSSProperties = {
+  margin: 0,
+  paddingLeft: "20px",
+  display: "grid",
+  gap: "8px",
+  fontSize: "14px",
+  color: "#374151",
+};
+
+const codeStyle: React.CSSProperties = {
+  fontFamily: "monospace",
+  backgroundColor: "#e2e8f0",
+  padding: "2px 6px",
+  borderRadius: "6px",
+  fontSize: "12px",
+};
+
+const twoColumnStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "24px",
+  gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+};
+
+const cardStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  padding: "24px",
+  borderRadius: "16px",
+  boxShadow: "0px 20px 40px rgba(15, 23, 42, 0.06)",
+  display: "grid",
+  gap: "16px",
+};
+
+const cardTitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "18px",
+};
+
+const orderedListStyle: React.CSSProperties = {
+  margin: 0,
+  paddingLeft: "20px",
+  display: "grid",
+  gap: "8px",
+  fontSize: "14px",
+  color: "#1f2937",
+};
+
+const definitionListStyle: React.CSSProperties = {
+  margin: 0,
+  display: "grid",
+  gap: "12px",
+  fontSize: "14px",
+  color: "#1f2937",
+};

--- a/webapp/src/admin-prototype/pages/RiskReviewFlowPage.tsx
+++ b/webapp/src/admin-prototype/pages/RiskReviewFlowPage.tsx
@@ -1,0 +1,218 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { fetchAlerts } from "../../api";
+import { getToken } from "../../auth";
+
+type AlertRecord = Awaited<ReturnType<typeof fetchAlerts>>["alerts"][number];
+
+type ReviewBucket = {
+  title: string;
+  description: string;
+  filter: (alert: AlertRecord) => boolean;
+};
+
+const reviewBuckets: ReviewBucket[] = [
+  {
+    title: "Payroll variance",
+    description:
+      "Flags when the secured PAYGW is short versus the withholding amount that payroll reported.",
+    filter: (alert) => alert.type === "PAYGW_SHORTFALL",
+  },
+  {
+    title: "GST cash exception",
+    description:
+      "Triggers whenever GST capture is skipped for 48 hours while the merchant account is still settling funds.",
+    filter: (alert) => alert.type === "GST_ESCROW_MISSED",
+  },
+  {
+    title: "Manual override",
+    description:
+      "Exposes any operator overrides so we can justify them during regulator walkthroughs.",
+    filter: (alert) => alert.type === "MANUAL_OVERRIDE",
+  },
+];
+
+export default function RiskReviewFlowPage() {
+  const token = getToken();
+  const [alerts, setAlerts] = useState<AlertRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      setError("No session token");
+      return;
+    }
+
+    (async () => {
+      try {
+        const response = await fetchAlerts(token);
+        setAlerts(response.alerts);
+        setError(null);
+      } catch (err) {
+        console.error(err);
+        setError("Unable to load alerts feed");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [token]);
+
+  const bucketSummaries = useMemo(() => {
+    return reviewBuckets.map((bucket) => ({
+      bucket,
+      alerts: alerts.filter(bucket.filter),
+    }));
+  }, [alerts]);
+
+  return (
+    <div style={{ display: "grid", gap: "24px" }}>
+      <header style={headerStyle}>
+        <h2 style={pageTitleStyle}>ATO risk review script</h2>
+        <p style={pageSubtitleStyle}>
+          Each bucket below maps a production alert to a regulator narrative. Use this to
+          show that our monitoring surface is the same one the compliance team works from
+          every day.
+        </p>
+      </header>
+
+      {loading && <div style={infoStyle}>Loading alerts from the API…</div>}
+      {error && <div style={errorStyle}>{error}</div>}
+
+      {!loading && !error && (
+        <section style={bucketsGridStyle}>
+          {bucketSummaries.map(({ bucket, alerts: bucketAlerts }) => (
+            <article key={bucket.title} style={bucketCardStyle}>
+              <h3 style={bucketTitleStyle}>{bucket.title}</h3>
+              <p style={bucketDescriptionStyle}>{bucket.description}</p>
+              <div style={bucketListStyle}>
+                {bucketAlerts.length === 0 && (
+                  <span style={emptyStateStyle}>No matching alerts in the current feed.</span>
+                )}
+                {bucketAlerts.map((alert) => (
+                  <div key={alert.id} style={alertRowStyle}>
+                    <span style={alertBadgeStyle}>{alert.severity}</span>
+                    <div style={{ display: "grid", gap: "4px" }}>
+                      <span style={alertMessageStyle}>{alert.message}</span>
+                      <span style={alertMetaStyle}>
+                        Raised {new Date(alert.createdAt).toLocaleString()} •{' '}
+                        {alert.resolved ? `Resolved ${new Date(alert.resolvedAt ?? "").toLocaleString()}` : "Open"}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}
+
+const headerStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  padding: "28px 32px",
+  borderRadius: "16px",
+  boxShadow: "0 28px 52px rgba(15, 23, 42, 0.07)",
+  display: "grid",
+  gap: "12px",
+};
+
+const pageTitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "22px",
+};
+
+const pageSubtitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "15px",
+  color: "#475569",
+  lineHeight: 1.5,
+};
+
+const infoStyle: React.CSSProperties = {
+  backgroundColor: "#e0f2fe",
+  color: "#075985",
+  padding: "12px 16px",
+  borderRadius: "8px",
+  fontSize: "14px",
+};
+
+const errorStyle: React.CSSProperties = {
+  backgroundColor: "#fee2e2",
+  color: "#b91c1c",
+  padding: "12px 16px",
+  borderRadius: "8px",
+  fontSize: "14px",
+};
+
+const bucketsGridStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "20px",
+};
+
+const bucketCardStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  padding: "24px",
+  borderRadius: "16px",
+  boxShadow: "0 24px 48px rgba(15, 23, 42, 0.05)",
+  display: "grid",
+  gap: "12px",
+};
+
+const bucketTitleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "18px",
+};
+
+const bucketDescriptionStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "14px",
+  color: "#475569",
+};
+
+const bucketListStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "10px",
+};
+
+const emptyStateStyle: React.CSSProperties = {
+  fontSize: "13px",
+  color: "#64748b",
+  backgroundColor: "#f8fafc",
+  padding: "10px 12px",
+  borderRadius: "8px",
+};
+
+const alertRowStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "auto 1fr",
+  gap: "12px",
+  padding: "14px 16px",
+  borderRadius: "12px",
+  backgroundColor: "#f1f5f9",
+};
+
+const alertBadgeStyle: React.CSSProperties = {
+  alignSelf: "flex-start",
+  padding: "6px 10px",
+  borderRadius: "999px",
+  backgroundColor: "#0b5fff",
+  color: "white",
+  fontSize: "12px",
+  fontWeight: 600,
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+};
+
+const alertMessageStyle: React.CSSProperties = {
+  fontSize: "14px",
+  fontWeight: 600,
+  color: "#1f2937",
+};
+
+const alertMetaStyle: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#475569",
+};

--- a/webapp/src/config.ts
+++ b/webapp/src/config.ts
@@ -1,0 +1,10 @@
+export const appConfig = {
+  featureFlags: {
+    adminPrototype:
+      (import.meta.env.VITE_ENABLE_ADMIN_PROTOTYPE ?? "")
+        .toString()
+        .toLowerCase() === "true",
+  },
+} as const;
+
+export type AppConfig = typeof appConfig;

--- a/webapp/src/vite-env.d.ts
+++ b/webapp/src/vite-env.d.ts
@@ -1,1 +1,9 @@
-﻿/// <reference types="vite/client" />
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_ADMIN_PROTOTYPE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add a configuration-based feature flag that enables the admin prototype experience
- introduce a dedicated admin-prototype router guarded by admin-only middleware
- scaffold overview, onboarding, and risk review placeholder pages fed by mock or existing services

## Testing
- pnpm --dir webapp build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126f9b34988327942164ce9f9e4585)