### PR TITLE
fix: use portable ledger test script

### DIFF
--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts",
-    "test": "..\\..\\node_modules\\.bin\\jest.cmd --config ../../jest.config.js --runTestsByPath ../../packages/ledger/tests/journalWriter.test.ts --coverage"
+    "test": "pnpm exec jest --config ../../jest.config.js --runTestsByPath ../../packages/ledger/tests/journalWriter.test.ts --coverage"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",


### PR DESCRIPTION
## Summary
- replace the Windows-specific jest invocation in the ledger package with a portable `pnpm exec` command so the test script runs on POSIX systems

## Testing
- pnpm --filter @apgms/ledger test
- pnpm -r test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912880d76148327be065568680d6388)