### PR TITLE
Fix ATO filer queue handling

### DIFF
--- a/worker/src/jobs/ato-filer.ts
+++ b/worker/src/jobs/ato-filer.ts
@@ -34,7 +34,9 @@ async function processStpQueue(client: AtoStpClient): Promise<void> {
   const candidates = await prisma.payRun.findMany({
     where: {
       status: "committed",
-      stpStatus: { in: ["PENDING", "RETRY"] },
+      stpStatus: {
+        in: ["PENDING", "RETRY", "ESCROW_BLOCKED", "ESCROW_DEFICIT"],
+      },
       stpReleaseAt: { lte: now },
     },
     orderBy: { createdAt: "asc" },
@@ -80,6 +82,7 @@ async function processBasQueue(client: AtoBasClient): Promise<void> {
       readyAt: { not: null, lte: now },
       releasedAt: { not: null, lte: now },
       lodgedAt: null,
+      status: { notIn: ["failed", "lodged", "escrow_blocked"] },
     },
     orderBy: { start: "asc" },
     take: 10,


### PR DESCRIPTION
## Summary
- include escrow-related STP statuses in the pay run query so previously blocked runs resume after release
- exclude terminal BAS period statuses when loading the queue to prevent repeated processing after failure or lodgement

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c67a55dc8327bf6d55b4523aaa9c)