### PR TITLE
Add helper script for updating branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ pnpm -w exec prisma migrate status
 git grep -n '<<<<<<<\|=======\|>>>>>>>' -- ':!*.lock' || true
 ```
 
+## Repository maintenance
+
+To keep every local branch aligned with its upstream remote, run the helper script below from a clean working tree:
+
+```bash
+./scripts/update-all-branches.sh
+```
+
+The script fetches remotes, iterates over each local branch, and fast-forwards it when possible before returning to your original branch. Resolve divergent branches manually when the script reports a failure.
+
 ---
 
 ## Accessibility & Performance

--- a/scripts/update-all-branches.sh
+++ b/scripts/update-all-branches.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "This script must be run from within a git repository" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is dirty; commit or stash changes before updating branches" >&2
+  exit 1
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+trap 'git switch --quiet "${current_branch}" >/dev/null 2>&1 || true' EXIT
+
+git fetch --all --prune
+
+while IFS= read -r branch; do
+  if [[ -z "${branch}" ]]; then
+    continue
+  fi
+
+  if [[ "${branch}" != "${current_branch}" ]]; then
+    git switch --quiet "${branch}"
+  fi
+
+  echo "Updating ${branch}"
+  git pull --ff-only --quiet || {
+    echo "Failed to fast-forward ${branch}; resolve manually" >&2
+    exit 1
+  }
+done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+
+git switch --quiet "${current_branch}"
+trap - EXIT
+echo "All local branches are up to date"


### PR DESCRIPTION
## Summary
- add a repository-maintenance script that fast-forwards every local branch after fetching remotes
- document the helper in the README so contributors know how to run it safely

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b0b754048327bf756b8182e6f75d)