### PR TITLE
Add audit logging to compliance evidence retrieval

### DIFF
--- a/services/api-gateway/src/prisma-augment.d.ts
+++ b/services/api-gateway/src/prisma-augment.d.ts
@@ -17,6 +17,7 @@ declare module '@prisma/client' {
   // Monitoring / evidence used in regulator routes
   type MonitoringSnapshot = any;
   type EvidenceArtifact = any;
+  type EvidenceAudit = any;
 
   // --- PrismaClient delegate augmentation ---------------------------------
   // The real PrismaClient is a generic class; we declare a matching generic
@@ -49,6 +50,7 @@ declare module '@prisma/client' {
     // From regulator
     monitoringSnapshot: any;
     evidenceArtifact: any;
+    evidenceAudit: any;
 
     // From compliance-proxy/regulator
     org: any;

--- a/services/api-gateway/src/routes/compliance-proxy.ts
+++ b/services/api-gateway/src/routes/compliance-proxy.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { authGuard } from "../auth.js";
 import { prisma } from "../db.js";
+import { redactEvidenceArtifact } from "../utils/compliance-artifacts.js";
 
 const formatPeriod = (start: Date, end: Date): string =>
   `${start.toISOString().slice(0, 10)}-${end.toISOString().slice(0, 10)}`;
@@ -161,6 +162,14 @@ export const registerComplianceProxy: FastifyPluginAsync = async (app) => {
   });
 
   app.get("/compliance/evidence/:artifactId", { preHandler: [authGuard] }, async (req, reply) => {
+    const user = (req.user as any) ?? {};
+    const orgId = user.orgId;
+
+    if (!orgId) {
+      reply.code(401).send({ error: "unauthorized" });
+      return;
+    }
+
     const artifactParamsSchema = z.object({ artifactId: z.string().min(1) });
     const parsed = artifactParamsSchema.safeParse(req.params ?? {});
     if (!parsed.success) {
@@ -173,11 +182,21 @@ export const registerComplianceProxy: FastifyPluginAsync = async (app) => {
     const artifact = await prisma.evidenceArtifact.findUnique({
       where: { id: parsed.data.artifactId },
     });
-    if (!artifact) {
+    if (!artifact || artifact.orgId !== orgId) {
       reply.code(404).send({ error: "artifact_not_found" });
       return;
     }
-    reply.send({ artifact });
+
+    await prisma.evidenceAudit.create({
+      data: {
+        artifactId: artifact.id,
+        orgId: artifact.orgId,
+        requesterId: user.sub ?? "unknown",
+      },
+    });
+
+    const includePayload = user.regulator === true;
+    reply.send({ artifact: redactEvidenceArtifact(artifact, includePayload) });
   });
 };
 

--- a/services/api-gateway/src/routes/regulator.ts
+++ b/services/api-gateway/src/routes/regulator.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 import { prisma } from "../db.js";
 import { recordAuditLog } from "../lib/audit.js";
+import { redactEvidenceArtifact } from "../utils/compliance-artifacts.js";
 
 type RegulatorRequest = FastifyRequest & {
   user?: { orgId?: string; sub?: string };
@@ -245,13 +246,7 @@ export async function registerRegulatorRoutes(
     );
 
     return {
-      artifacts: artifacts.map((artifact) => ({
-        id: artifact.id,
-        kind: artifact.kind,
-        sha256: artifact.sha256,
-        wormUri: artifact.wormUri,
-        createdAt: artifact.createdAt.toISOString(),
-      })),
+      artifacts: artifacts.map((artifact) => redactEvidenceArtifact(artifact)),
     };
   });
 
@@ -283,14 +278,7 @@ export async function registerRegulatorRoutes(
     );
 
     return {
-      artifact: {
-        id: artifact.id,
-        kind: artifact.kind,
-        sha256: artifact.sha256,
-        wormUri: artifact.wormUri,
-        createdAt: artifact.createdAt.toISOString(),
-        payload: artifact.payload ?? null,
-      },
+      artifact: redactEvidenceArtifact(artifact, true),
     };
   });
 

--- a/services/api-gateway/src/utils/compliance-artifacts.ts
+++ b/services/api-gateway/src/utils/compliance-artifacts.ts
@@ -1,0 +1,29 @@
+// services/api-gateway/src/utils/compliance-artifacts.ts
+import type { EvidenceArtifact } from "@prisma/client";
+
+export function redactEvidenceArtifact(
+  artifact: EvidenceArtifact | null | undefined,
+  includePayload = false,
+) {
+  if (!artifact) return artifact;
+
+  const metadata = {
+    id: artifact.id,
+    kind: artifact.kind,
+    sha256: artifact.sha256,
+    wormUri: artifact.wormUri,
+    createdAt:
+      artifact.createdAt instanceof Date
+        ? artifact.createdAt.toISOString()
+        : artifact.createdAt,
+  };
+
+  if (!includePayload) {
+    return metadata;
+  }
+
+  return {
+    ...metadata,
+    payload: artifact.payload ?? null,
+  };
+}

--- a/shared/prisma/migrations/20251109140000_evidence_audit_logs/migration.sql
+++ b/shared/prisma/migrations/20251109140000_evidence_audit_logs/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "EvidenceAudit" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "orgId" UUID NOT NULL,
+  "artifactId" UUID NOT NULL REFERENCES "EvidenceArtifact"("id") ON DELETE CASCADE,
+  "requesterId" TEXT NOT NULL,
+  "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "EvidenceAudit_artifactId_createdAt_idx" ON "EvidenceAudit" ("artifactId", "createdAt");
+CREATE INDEX "EvidenceAudit_orgId_createdAt_idx" ON "EvidenceAudit" ("orgId", "createdAt");

--- a/shared/prisma/schema.prisma
+++ b/shared/prisma/schema.prisma
@@ -306,6 +306,17 @@ model EvidenceArtifact {
   @@index([orgId, kind])
 }
 
+model EvidenceAudit {
+  id          String   @id @default(uuid()) @db.Uuid
+  orgId       String   @db.Uuid
+  artifactId  String   @db.Uuid
+  requesterId String
+  createdAt   DateTime @default(now())
+
+  @@index([artifactId, createdAt])
+  @@index([orgId, createdAt])
+}
+
 // =========================
 // Legacy models still used by the live Fastify API
 // =========================


### PR DESCRIPTION
## Summary
- add a compliance artifact redaction helper and reuse it across evidence endpoints
- log evidence access with append-only EvidenceAudit records scoped to the requester and org
- introduce a Prisma EvidenceAudit model and migration to persist audit entries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692342d2d3648327bf2c8a7ada57ec9d)