### PR TITLE
Add validation and idempotency coverage for critical API routes

### DIFF
--- a/services/api-gateway/src/routes/regulator.ts
+++ b/services/api-gateway/src/routes/regulator.ts
@@ -192,7 +192,7 @@ export async function registerRegulatorRoutes(
     };
   });
 
-  app.get("/monitoring/snapshots", async (request: RegulatorRequest) => {
+  app.get("/monitoring/snapshots", async (request: RegulatorRequest, reply) => {
     const orgId = ensureOrgId(request);
 
     const querySchema = z.object({
@@ -206,9 +206,10 @@ export async function registerRegulatorRoutes(
 
     const parsed = querySchema.safeParse(request.query ?? {});
     if (!parsed.success) {
-      return {
-        error: { code: "invalid_query", details: parsed.error.flatten() },
-      };
+      reply
+        .code(400)
+        .send({ error: { code: "invalid_query", details: parsed.error.flatten() } });
+      return;
     }
     const limit = parsed.data.limit;
 

--- a/services/api-gateway/test/payment-plans.validation.test.ts
+++ b/services/api-gateway/test/payment-plans.validation.test.ts
@@ -1,0 +1,112 @@
+import Fastify from "fastify";
+
+import { registerPaymentPlanRoutes } from "../src/routes/payment-plans";
+import {
+  createPaymentPlanRequest,
+  listPaymentPlans,
+  updatePaymentPlanStatus,
+} from "@apgms/shared";
+import { prisma } from "../src/db";
+
+jest.mock("../src/auth", () => ({
+  authGuard: (_req: any, _reply: any, done: () => void) => done(),
+}));
+
+jest.mock("@apgms/shared", () => ({
+  createPaymentPlanRequest: jest.fn(),
+  listPaymentPlans: jest.fn(),
+  updatePaymentPlanStatus: jest.fn(),
+  buildPaymentPlanNarrative: jest.fn().mockReturnValue("summary"),
+}));
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    paymentPlanRequest: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+const mockUser = { orgId: "org-1", sub: "user-1", role: "admin" };
+
+const makeApp = (user: any) => {
+  const app = Fastify();
+  app.decorateRequest("user", null as any);
+  app.addHook("onRequest", (req, _rep, done) => {
+    (req as any).user = user;
+    done();
+  });
+  app.register(registerPaymentPlanRoutes);
+  return app;
+};
+
+describe("payment plans validation/auth", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (listPaymentPlans as jest.Mock).mockResolvedValue([]);
+    (createPaymentPlanRequest as jest.Mock).mockResolvedValue({ id: "pp-1" });
+    (updatePaymentPlanStatus as jest.Mock).mockResolvedValue({ id: "pp-1", status: "APPROVED" });
+    (prisma as any).paymentPlanRequest.findUnique.mockResolvedValue({
+      id: "pp-1",
+      orgId: "org-1",
+      basCycleId: "bas-1",
+      reason: "Need a plan",
+      status: "REQUESTED",
+      detailsJson: {},
+      requestedAt: new Date(),
+    });
+  });
+
+  it("401 when unauthenticated", async () => {
+    const app = makeApp(null);
+    const res = await app.inject({ method: "GET", url: "/payment-plans" });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("403 when role missing", async () => {
+    const app = makeApp({ orgId: "org-1", sub: "user-1" });
+    const res = await app.inject({ method: "GET", url: "/payment-plans" });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it("400 on invalid creation body", async () => {
+    const app = makeApp(mockUser);
+    const res = await app.inject({
+      method: "POST",
+      url: "/payment-plans",
+      payload: { basCycleId: "", reason: "short" },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("happy path creates payment plan", async () => {
+    const app = makeApp(mockUser);
+    const res = await app.inject({
+      method: "POST",
+      url: "/payment-plans",
+      payload: { basCycleId: "bas-1", reason: "Need more time", details: { note: true } },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(createPaymentPlanRequest).toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("403 when accessing another org summary", async () => {
+    const app = makeApp(mockUser);
+    (prisma as any).paymentPlanRequest.findUnique.mockResolvedValueOnce({
+      id: "pp-2",
+      orgId: "other-org",
+      basCycleId: "bas-2",
+      reason: "Other org",
+      status: "REQUESTED",
+      detailsJson: {},
+      requestedAt: new Date(),
+    });
+    const res = await app.inject({ method: "GET", url: "/payment-plans/pp-2/summary" });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+});

--- a/services/api-gateway/test/regulator.validation.test.ts
+++ b/services/api-gateway/test/regulator.validation.test.ts
@@ -1,0 +1,111 @@
+import Fastify from "fastify";
+
+import { registerRegulatorRoutes } from "../src/routes/regulator";
+
+jest.mock("../src/db", () => ({ prisma: {} }));
+
+const now = new Date();
+const stubPrisma = {
+  basCycle: {
+    findMany: jest.fn().mockResolvedValue([]),
+    findFirst: jest.fn().mockResolvedValue(null),
+  },
+  paymentPlanRequest: {
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+  alert: {
+    count: jest.fn().mockResolvedValue(0),
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+  designatedAccount: {
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+  monitoringSnapshot: {
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+  evidenceArtifact: {
+    findMany: jest.fn().mockResolvedValue([]),
+    findUnique: jest.fn().mockResolvedValue(null),
+  },
+  bankLine: {
+    aggregate: jest.fn().mockResolvedValue({ _count: { id: 0 }, _sum: { amount: 0 } }),
+    findFirst: jest.fn().mockResolvedValue({ id: "bl-1", orgId: "org-1", date: now, amount: 1, createdAt: now }),
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+};
+
+const makeApp = (auth?: { user?: any; regulatorSession?: any }) => {
+  const app = Fastify();
+  app.decorateRequest("user", null as any);
+  app.decorateRequest("regulatorSession", null as any);
+  app.addHook("onRequest", (req, reply, done) => {
+    if (!auth) {
+      reply.code(401).send({ error: "unauthenticated" });
+      return;
+    }
+    if (!auth.regulatorSession && auth.user?.role !== "regulator") {
+      reply.code(403).send({ error: "forbidden" });
+      return;
+    }
+    (req as any).user = auth.user;
+    (req as any).regulatorSession = auth.regulatorSession;
+    done();
+  });
+  app.register(async (regScope) => {
+    await registerRegulatorRoutes(regScope, { prisma: stubPrisma as any, auditLogger: async () => {} });
+  }, { prefix: "/regulator" });
+  return app;
+};
+
+describe("regulator route validation/auth", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    stubPrisma.basCycle.findMany.mockResolvedValue([]);
+    stubPrisma.basCycle.findFirst.mockResolvedValue(null);
+    stubPrisma.paymentPlanRequest.findMany.mockResolvedValue([]);
+    stubPrisma.alert.count.mockResolvedValue(0);
+    stubPrisma.alert.findMany.mockResolvedValue([]);
+    stubPrisma.designatedAccount.findMany.mockResolvedValue([]);
+    stubPrisma.monitoringSnapshot.findMany.mockResolvedValue([]);
+    stubPrisma.evidenceArtifact.findMany.mockResolvedValue([]);
+    stubPrisma.evidenceArtifact.findUnique.mockResolvedValue(null);
+    stubPrisma.bankLine.aggregate.mockResolvedValue({ _count: { id: 0 }, _sum: { amount: 0 } });
+    stubPrisma.bankLine.findFirst.mockResolvedValue({
+      id: "bl-1",
+      orgId: "org-1",
+      date: now,
+      amount: 1,
+      createdAt: now,
+    });
+    stubPrisma.bankLine.findMany.mockResolvedValue([]);
+  });
+
+  it("401 when unauthenticated", async () => {
+    const app = makeApp(undefined);
+    const res = await app.inject({ method: "GET", url: "/regulator/health" });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("403 when wrong role", async () => {
+    const app = makeApp({ user: { orgId: "org-1", sub: "user-1", role: "admin" } });
+    const res = await app.inject({ method: "GET", url: "/regulator/health" });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it("400 on invalid query", async () => {
+    const app = makeApp({ regulatorSession: { id: "sess-1", orgId: "org-1" } });
+    const res = await app.inject({ method: "GET", url: "/regulator/monitoring/snapshots?limit=0" });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("happy path returns reports", async () => {
+    const app = makeApp({ regulatorSession: { id: "sess-1", orgId: "org-1" } });
+    const res = await app.inject({ method: "GET", url: "/regulator/compliance/report" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().orgId).toBe("org-1");
+    await app.close();
+  });
+});

--- a/services/api-gateway/test/transfers.validation.test.ts
+++ b/services/api-gateway/test/transfers.validation.test.ts
@@ -1,0 +1,135 @@
+import Fastify from "fastify";
+
+import { registerTransferRoutes } from "../src/routes/transfers";
+import { prisma } from "../src/db";
+import { markTransferStatus } from "@apgms/shared";
+import { recordCriticalAuditLog } from "../src/lib/audit";
+
+jest.mock("../src/db", () => ({
+  prisma: {
+    idempotencyEntry: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../src/observability/metrics", () => ({
+  metrics: {
+    transferExecutionTotal: { inc: jest.fn() },
+  },
+}));
+
+jest.mock("@apgms/shared", () => ({
+  markTransferStatus: jest.fn(),
+  conflict: (code: string, message: string) =>
+    Object.assign(new Error(`${code}:${message}`), { code }),
+}));
+
+jest.mock("../src/lib/audit", () => ({
+  recordCriticalAuditLog: jest.fn(),
+}));
+
+const mockUser = { orgId: "org-1", sub: "user-1", role: "admin" };
+
+const makeApp = (user: any) => {
+  const app = Fastify();
+  app.decorateRequest("user", null as any);
+  app.addHook("onRequest", (req, _rep, done) => {
+    (req as any).user = user;
+    done();
+  });
+  app.register(registerTransferRoutes);
+  return app;
+};
+
+describe("transfers validation/auth/idempotency", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("401 when unauthenticated", async () => {
+    const app = makeApp(null);
+    const res = await app.inject({
+      method: "POST",
+      url: "/bas/transfer",
+      payload: { instructionId: "abc", mfaCode: "0000" },
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("403 when role missing", async () => {
+    const app = makeApp({ orgId: "org-1", sub: "user-1" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/bas/transfer",
+      payload: { instructionId: "abc", mfaCode: "0000" },
+    });
+    expect(res.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it("400 on invalid body", async () => {
+    const app = makeApp(mockUser);
+    const res = await app.inject({
+      method: "POST",
+      url: "/bas/transfer",
+      payload: { instructionId: "", mfaCode: "0" },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("idempotent replay returns header", async () => {
+    const app = makeApp(mockUser);
+    (prisma as any).idempotencyEntry.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "ide-1" });
+    (prisma as any).idempotencyEntry.create.mockResolvedValueOnce({ id: "ide-1" });
+    (prisma as any).idempotencyEntry.update.mockResolvedValue({});
+    (markTransferStatus as jest.Mock).mockResolvedValue(undefined);
+    (recordCriticalAuditLog as jest.Mock).mockResolvedValue(undefined);
+
+    const payload = { instructionId: "inst-1", mfaCode: "0000" };
+    const first = await app.inject({
+      method: "POST",
+      url: "/bas/transfer",
+      payload,
+      headers: { "idempotency-key": "idem-1" },
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.headers["idempotent-replay"]).toBe("false");
+
+    const second = await app.inject({
+      method: "POST",
+      url: "/bas/transfer",
+      payload,
+      headers: { "idempotency-key": "idem-1" },
+    });
+    expect(second.statusCode).toBe(409);
+    expect(second.headers["idempotent-replay"]).toBe("true");
+    await app.close();
+  });
+
+  it("happy path sends transfer", async () => {
+    const app = makeApp(mockUser);
+    (prisma as any).idempotencyEntry.findUnique.mockResolvedValueOnce(null);
+    (prisma as any).idempotencyEntry.create.mockResolvedValueOnce({ id: "ide-2" });
+    (prisma as any).idempotencyEntry.update.mockResolvedValue({});
+    (markTransferStatus as jest.Mock).mockResolvedValue(undefined);
+    (recordCriticalAuditLog as jest.Mock).mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/bas/transfer",
+      payload: { instructionId: "inst-2", mfaCode: "0000" },
+      headers: { "idempotency-key": "idem-2" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["idempotent-replay"]).toBe("false");
+    expect(markTransferStatus).toHaveBeenCalledWith("inst-2", "sent");
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add route-level zod validation and role checks for BAS, payment plans, transfers, and regulator snapshots
- introduce Jest integration tests covering auth, validation, idempotency, and happy paths for key API gateway routes

## Testing
- pnpm jest --runTestsByPath services/api-gateway/test/transfers.validation.test.ts services/api-gateway/test/bas.validation.test.ts services/api-gateway/test/payment-plans.validation.test.ts services/api-gateway/test/regulator.validation.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242f9360ec83278d95c3790982259b)